### PR TITLE
Switching to derive_where for some impls

### DIFF
--- a/crates/bonsaidb-client/Cargo.toml
+++ b/crates/bonsaidb-client/Cargo.toml
@@ -34,6 +34,7 @@ bincode = { version = "1", optional = true }
 async-lock = "2"
 js-sys = "0.3"
 log = "0.4"
+derive-where = { git = "https://github.com/khonsulabs/derive-where.git", branch = "tests" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = [

--- a/crates/bonsaidb-client/Cargo.toml
+++ b/crates/bonsaidb-client/Cargo.toml
@@ -34,7 +34,7 @@ bincode = { version = "1", optional = true }
 async-lock = "2"
 js-sys = "0.3"
 log = "0.4"
-derive-where = { git = "https://github.com/khonsulabs/derive-where.git", branch = "tests" }
+derive-where = "1.0.0-rc.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = [

--- a/crates/bonsaidb-client/src/client.rs
+++ b/crates/bonsaidb-client/src/client.rs
@@ -26,6 +26,7 @@ use bonsaidb_core::{
     permissions::Permissions,
     schema::{NamedReference, Schema, SchemaName, Schematic},
 };
+use derive_where::DeriveWhere;
 use flume::Sender;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::task::JoinHandle;
@@ -69,17 +70,10 @@ pub type WebSocketError = tokio_tungstenite::tungstenite::Error;
 pub type WebSocketError = wasm_websocket_worker::WebSocketError;
 
 /// Client for connecting to a `BonsaiDb` server.
-#[derive(Debug)]
+#[derive(Debug, DeriveWhere)]
+#[derive_where(Clone)]
 pub struct Client<A: CustomApi = ()> {
     pub(crate) data: Arc<Data<A>>,
-}
-
-impl<A: CustomApi> Clone for Client<A> {
-    fn clone(&self) -> Self {
-        Self {
-            data: self.data.clone(),
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/crates/bonsaidb-client/src/client/remote_database.rs
+++ b/crates/bonsaidb-client/src/client/remote_database.rs
@@ -9,6 +9,7 @@ use bonsaidb_core::{
     schema::{view, view::map, Collection, Key, Map, MappedDocument, MappedValue, Schematic, View},
     transaction::{Executed, OperationResult, Transaction},
 };
+use derive_where::DeriveWhere;
 
 use crate::Client;
 
@@ -18,7 +19,8 @@ pub use pubsub::*;
 mod keyvalue;
 
 /// A database on a remote server.
-#[derive(Debug)]
+#[derive(Debug, DeriveWhere)]
+#[derive_where(Clone)]
 pub struct RemoteDatabase<A: CustomApi = ()> {
     client: Client<A>,
     name: Arc<String>,
@@ -37,16 +39,6 @@ impl<A: CustomApi> Deref for RemoteDatabase<A> {
 
     fn deref(&self) -> &Self::Target {
         &self.client
-    }
-}
-
-impl<A: CustomApi> Clone for RemoteDatabase<A> {
-    fn clone(&self) -> Self {
-        Self {
-            client: self.client.clone(),
-            name: self.name.clone(),
-            schema: self.schema.clone(),
-        }
     }
 }
 

--- a/crates/bonsaidb-core/Cargo.toml
+++ b/crates/bonsaidb-core/Cargo.toml
@@ -45,6 +45,7 @@ bincode = { version = "1", optional = true }
 serde_cbor = { version = "0.11", optional = true }
 itertools = "0.10"
 ordered-varint = "0.1.0-dev.1"
+derive-where = { git = "https://github.com/khonsulabs/derive-where.git", branch = "tests" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/crates/bonsaidb-core/Cargo.toml
+++ b/crates/bonsaidb-core/Cargo.toml
@@ -45,7 +45,7 @@ bincode = { version = "1", optional = true }
 serde_cbor = { version = "0.11", optional = true }
 itertools = "0.10"
 ordered-varint = "0.1.0-dev.1"
-derive-where = { git = "https://github.com/khonsulabs/derive-where.git", branch = "tests" }
+derive-where = "1.0.0-rc.1"
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/crates/bonsaidb-core/src/networking.rs
+++ b/crates/bonsaidb-core/src/networking.rs
@@ -3,6 +3,7 @@ use custodian_password::{
     LoginFinalization, LoginRequest, LoginResponse, RegistrationFinalization, RegistrationRequest,
     RegistrationResponse,
 };
+use derive_where::DeriveWhere;
 use schema::SchemaName;
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +26,8 @@ pub struct Payload<T> {
 }
 
 /// A request made to a server.
-#[derive(Clone, Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, DeriveWhere)]
+#[derive_where(Debug)]
 #[cfg_attr(feature = "actionable-traits", derive(actionable::Actionable))]
 pub enum Request<T> {
     /// A server-related request.
@@ -46,6 +48,7 @@ pub enum Request<T> {
         feature = "actionable-traits",
         actionable(protection = "none", subaction)
     )]
+    #[derive_where(skip_inner)]
     Api(T),
 }
 
@@ -294,7 +297,8 @@ pub enum DatabaseRequest {
 }
 
 /// A response from a server.
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, DeriveWhere)]
+#[derive_where(Debug)]
 pub enum Response<T> {
     /// A request succeded but provided no output.
     Ok,
@@ -303,6 +307,7 @@ pub enum Response<T> {
     /// A response to a [`DatabaseRequest`].
     Database(DatabaseResponse),
     /// A response to an Api request.
+    #[derive_where(skip_inner)]
     Api(T),
     /// An error occurred processing a request.
     Error(crate::Error),

--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -59,6 +59,7 @@ tracing = { version = "0.1", optional = true, default-features = false, features
     "attributes",
 ] }
 log = "0.4"
+derive-where = { git = "https://github.com/khonsulabs/derive-where.git", branch = "tests" }
 
 [dev-dependencies]
 bonsaidb-core = { path = "../bonsaidb-core", version = "0.1.0-dev.4", features = [

--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -59,7 +59,7 @@ tracing = { version = "0.1", optional = true, default-features = false, features
     "attributes",
 ] }
 log = "0.4"
-derive-where = { git = "https://github.com/khonsulabs/derive-where.git", branch = "tests" }
+derive-where = "1.0.0-rc.1"
 
 [dev-dependencies]
 bonsaidb-core = { path = "../bonsaidb-core", version = "0.1.0-dev.4", features = [

--- a/crates/bonsaidb-local/src/jobs/manager.rs
+++ b/crates/bonsaidb-local/src/jobs/manager.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Debug, sync::Arc};
 
+use derive_where::DeriveWhere;
 use tokio::sync::RwLock;
 
 use crate::jobs::{
@@ -15,8 +16,10 @@ pub(crate) use managed_job::ManagedJob;
 mod tests;
 
 /// A background jobs manager.
-#[derive(Debug)]
+#[derive(Debug, DeriveWhere)]
+#[derive_where(Clone)]
 pub struct Manager<Key = ()> {
+    // #[derive_where(default)]
     pub(crate) jobs: Arc<RwLock<jobs::Jobs<Key>>>,
 }
 
@@ -27,14 +30,6 @@ where
     fn default() -> Self {
         Self {
             jobs: Arc::new(RwLock::new(jobs::Jobs::new())),
-        }
-    }
-}
-
-impl<Key> Clone for Manager<Key> {
-    fn clone(&self) -> Self {
-        Self {
-            jobs: self.jobs.clone(),
         }
     }
 }

--- a/crates/bonsaidb-local/src/jobs/manager.rs
+++ b/crates/bonsaidb-local/src/jobs/manager.rs
@@ -17,21 +17,10 @@ mod tests;
 
 /// A background jobs manager.
 #[derive(Debug, DeriveWhere)]
-#[derive_where(Clone)]
+#[derive_where(Clone, Default)]
 pub struct Manager<Key = ()> {
     // #[derive_where(default)]
     pub(crate) jobs: Arc<RwLock<jobs::Jobs<Key>>>,
-}
-
-impl<Key> Default for Manager<Key>
-where
-    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
-{
-    fn default() -> Self {
-        Self {
-            jobs: Arc::new(RwLock::new(jobs::Jobs::new())),
-        }
-    }
 }
 
 impl<Key> Manager<Key>

--- a/crates/bonsaidb-local/src/jobs/manager/jobs.rs
+++ b/crates/bonsaidb-local/src/jobs/manager/jobs.rs
@@ -18,11 +18,8 @@ pub struct Jobs<Key> {
     queue: Receiver<Box<dyn Executable>>,
 }
 
-impl<Key> Jobs<Key>
-where
-    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
-{
-    pub fn new() -> Self {
+impl<Key> Default for Jobs<Key> {
+    fn default() -> Self {
         let (queuer, queue) = flume::unbounded();
 
         Self {
@@ -33,7 +30,12 @@ where
             queue,
         }
     }
+}
 
+impl<Key> Jobs<Key>
+where
+    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
+{
     pub fn queue(&self) -> Receiver<Box<dyn Executable>> {
         self.queue.clone()
     }

--- a/crates/bonsaidb-server/Cargo.toml
+++ b/crates/bonsaidb-server/Cargo.toml
@@ -64,6 +64,7 @@ tracing = { version = "0.1", optional = true, default-features = false, features
 log = "0.4"
 signal-hook = "0.3"
 env_logger = { version = "0.9", optional = true }
+derive-where = { git = "https://github.com/khonsulabs/derive-where.git", branch = "tests" }
 
 
 [dev-dependencies]

--- a/crates/bonsaidb-server/Cargo.toml
+++ b/crates/bonsaidb-server/Cargo.toml
@@ -64,7 +64,7 @@ tracing = { version = "0.1", optional = true, default-features = false, features
 log = "0.4"
 signal-hook = "0.3"
 env_logger = { version = "0.9", optional = true }
-derive-where = { git = "https://github.com/khonsulabs/derive-where.git", branch = "tests" }
+derive-where = "1.0.0-rc.1"
 
 
 [dev-dependencies]

--- a/crates/bonsaidb-server/src/server.rs
+++ b/crates/bonsaidb-server/src/server.rs
@@ -45,6 +45,7 @@ use bonsaidb_local::{
     jobs::{manager::Manager, Job},
     OpenDatabase, Storage,
 };
+use derive_where::DeriveWhere;
 use fabruic::{self, CertificateChain, Endpoint, KeyPair, PrivateKey};
 use flume::Sender;
 use futures::{Future, StreamExt};
@@ -84,21 +85,14 @@ pub use self::{
 static CONNECTED_CLIENT_ID_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// A `BonsaiDb` server.
-#[derive(Debug)]
+#[derive(Debug, DeriveWhere)]
+#[derive_where(Clone)]
 pub struct CustomServer<B: Backend> {
     data: Arc<Data<B>>,
 }
 
 /// A `BonsaiDb` server without a custom backend.
 pub type Server = CustomServer<()>;
-
-impl<B: Backend> Clone for CustomServer<B> {
-    fn clone(&self) -> Self {
-        Self {
-            data: self.data.clone(),
-        }
-    }
-}
 
 #[derive(Debug)]
 struct Data<B: Backend = ()> {

--- a/crates/bonsaidb-server/src/server/connected_client.rs
+++ b/crates/bonsaidb-server/src/server/connected_client.rs
@@ -9,6 +9,7 @@ use bonsaidb_core::{
     custom_api::CustomApiResult,
     permissions::Permissions,
 };
+use derive_where::DeriveWhere;
 use flume::Sender;
 use tokio::sync::{Mutex, MutexGuard, RwLock};
 
@@ -25,7 +26,8 @@ pub enum Transport {
 }
 
 /// A connected database client.
-#[derive(Debug)]
+#[derive(Debug, DeriveWhere)]
+#[derive_where(Clone)]
 pub struct ConnectedClient<B: Backend = ()> {
     data: Arc<Data<B>>,
 }
@@ -45,14 +47,6 @@ struct Data<B: Backend = ()> {
 struct AuthenticationState {
     user_id: Option<u64>,
     permissions: Permissions,
-}
-
-impl<B: Backend> Clone for ConnectedClient<B> {
-    fn clone(&self) -> Self {
-        Self {
-            data: self.data.clone(),
-        }
-    }
 }
 
 impl<B: Backend> ConnectedClient<B> {


### PR DESCRIPTION
This will likely be merged ahead of #87, as my understanding is that it will be published in preparation for updating the custodian-password dependencies.

Going to wait to merge this until it has a published version on crates.io.