### PR TITLE
Implementing Semi-Transactional KeyValue Store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 # fabruic = { path = "../fabruic", version = "0.0.1-dev.3" }
 # actionable = { git="https://github.com/khonsulabs/actionable.git", branch="main" }
 # actionable = { path = "../actionable/actionable", version = "0.1.0-rc.1" }
-# nebari = { path = "../nebari/nebari", version = "0.1.0-rc.3" }
+# nebari = { path = "../nebari/nebari", version = "0.1" }
 # nebari = { git = "https://github.com/khonsulabs/nebari.git", branch = "main" }
 
 # [patch."https://github.com/khonsulabs/custodian.git"]

--- a/crates/bonsaidb-core/src/keyvalue.rs
+++ b/crates/bonsaidb-core/src/keyvalue.rs
@@ -204,20 +204,7 @@ pub struct KeyOperation {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum Command {
     /// Set a key/value pair.
-    Set {
-        /// The value.
-        value: Value,
-        /// If set, the key will be set to expire automatically.
-        expiration: Option<Timestamp>,
-        /// If true and the key already exists, the expiration will not be
-        /// updated. If false and an expiration is provided, the expiration will
-        /// be set.
-        keep_existing_expiration: bool,
-        /// Conditional checks for whether the key is already present or not.
-        check: Option<KeyCheck>,
-        /// If true and the key already exists, the existing key will be returned if overwritten.
-        return_previous_value: bool,
-    },
+    Set(SetCommand),
     /// Get the value from a key.
     Get {
         /// Remove the key after retrieving the value.
@@ -247,6 +234,23 @@ pub enum Command {
     },
     /// Delete a key.
     Delete,
+}
+
+/// Set a key/value pair.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct SetCommand {
+    /// The value.
+    pub value: Value,
+    /// If set, the key will be set to expire automatically.
+    pub expiration: Option<Timestamp>,
+    /// If true and the key already exists, the expiration will not be
+    /// updated. If false and an expiration is provided, the expiration will
+    /// be set.
+    pub keep_existing_expiration: bool,
+    /// Conditional checks for whether the key is already present or not.
+    pub check: Option<KeyCheck>,
+    /// If true and the key already exists, the existing key will be returned if overwritten.
+    pub return_previous_value: bool,
 }
 
 /// A value stored in a key.

--- a/crates/bonsaidb-core/src/keyvalue/implementation/set.rs
+++ b/crates/bonsaidb-core/src/keyvalue/implementation/set.rs
@@ -10,7 +10,10 @@ use super::{
     BuilderState, Command, KeyCheck, KeyOperation, KeyStatus, KeyValue, Output, PendingValue,
     Timestamp,
 };
-use crate::{keyvalue::Value, Error};
+use crate::{
+    keyvalue::{SetCommand, Value},
+    Error,
+};
 
 /// Executes [`Command::Set`] when awaited. Also offers methods to customize the
 /// options for the operation.
@@ -112,13 +115,13 @@ where
                 .execute_key_operation(KeyOperation {
                     namespace,
                     key,
-                    command: Command::Set {
+                    command: Command::Set(SetCommand {
                         value: value.prepare()?,
                         expiration,
                         keep_existing_expiration,
                         check,
                         return_previous_value: true,
-                    },
+                    }),
                 })
                 .await?;
             match result {
@@ -172,13 +175,13 @@ where
                         .execute_key_operation(KeyOperation {
                             namespace,
                             key,
-                            command: Command::Set {
+                            command: Command::Set(SetCommand {
                                 value: value.prepare()?,
                                 expiration,
                                 keep_existing_expiration,
                                 check,
                                 return_previous_value: false,
-                            },
+                            }),
                         })
                         .await?;
                     if let Output::Status(status) = result {

--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -35,7 +35,7 @@ included-from-omnibus = []
 async-trait = "0.1"
 bonsaidb-core = { path = "../bonsaidb-core", version = "0.1.0-dev.4" }
 bonsaidb-utils = { path = "../bonsaidb-utils", version = "0.1.0-dev.4" }
-nebari = { version = "0.1.0-rc.6" }
+nebari = { version = "0.1" }
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/bonsaidb-local/src/config.rs
+++ b/crates/bonsaidb-local/src/config.rs
@@ -125,7 +125,7 @@ pub struct Views {
 /// let persistence = KeyValuePersistence::lazy([
 ///   PersistenceThreshold::after_changes(1).and_duration(Duration::from_secs(120)),
 ///   PersistenceThreshold::after_changes(10).and_duration(Duration::from_secs(10)),
-///     PersistenceThreshold::after_changes(100),
+///   PersistenceThreshold::after_changes(100),
 /// ]);
 ///
 /// // After 1 change and 60 seconds, no changes would be committed:

--- a/crates/bonsaidb-local/src/database.rs
+++ b/crates/bonsaidb-local/src/database.rs
@@ -38,7 +38,7 @@ use nebari::{
 #[cfg(feature = "encryption")]
 use crate::vault::TreeVault;
 use crate::{
-    config::{Builder, StorageConfiguration},
+    config::{Builder, KeyValuePersistence, StorageConfiguration},
     error::Error,
     open_trees::OpenTrees,
     storage::{AnyBackupLocation, OpenDatabase},
@@ -1235,14 +1235,14 @@ impl Borrow<Roots<StdFile>> for Context {
 }
 
 impl Context {
-    pub(crate) fn new(roots: Roots<StdFile>) -> Self {
+    pub(crate) fn new(roots: Roots<StdFile>, key_value_persistence: KeyValuePersistence) -> Self {
         let (kv_operation_sender, kv_operation_receiver) = flume::unbounded();
         let context = Self {
             roots: roots.clone(),
             kv_operation_sender,
         };
         tokio::task::spawn(async move {
-            keyvalue::KeyValueManager::new(kv_operation_receiver, roots)
+            keyvalue::KeyValueManager::new(kv_operation_receiver, roots, key_value_persistence)
                 .run()
                 .await
         });

--- a/crates/bonsaidb-local/src/database.rs
+++ b/crates/bonsaidb-local/src/database.rs
@@ -1249,6 +1249,18 @@ impl Context {
         context
     }
 
+    pub(crate) async fn perform_kv_operation(
+        &self,
+        op: KeyOperation,
+    ) -> Result<Output, bonsaidb_core::Error> {
+        let (result_sender, result_receiver) = flume::bounded(1);
+        self.kv_operation_sender
+            .send((keyvalue::ManagerOp::Op(op), result_sender))
+            .map_err(Error::from_send)?;
+
+        result_receiver.recv_async().await.map_err(Error::from)?
+    }
+
     pub(crate) async fn update_key_expiration_async(
         &self,
         tree_key: String,

--- a/crates/bonsaidb-local/src/database/keyvalue.rs
+++ b/crates/bonsaidb-local/src/database/keyvalue.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Borrow,
     collections::{HashMap, VecDeque},
     convert::Infallible,
     sync::atomic::{AtomicBool, Ordering},
@@ -8,18 +7,19 @@ use std::{
 use async_trait::async_trait;
 use bonsaidb_core::{
     keyvalue::{
-        Command, KeyCheck, KeyOperation, KeyStatus, KeyValue, Numeric, Output, Timestamp, Value,
+        Command, KeyCheck, KeyOperation, KeyStatus, KeyValue, Numeric, Output, SetCommand,
+        Timestamp, Value,
     },
     transaction::{ChangedKey, Changes},
 };
 use nebari::{
     io::fs::StdFile,
     tree::{KeyEvaluation, Root, Unversioned},
-    AbortError, Buffer, CompareAndSwapError, ExecutingTransaction, Roots, TransactionTree,
+    AbortError, Buffer, ExecutingTransaction, Roots, TransactionTree,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{database::Context, jobs::Job, Database, Error};
+use crate::{jobs::Job, Database, Error};
 
 #[derive(Serialize, Deserialize)]
 pub struct Entry {
@@ -34,24 +34,20 @@ impl Entry {
         key: String,
         database: &Database,
     ) -> Result<(), bonsaidb_core::Error> {
-        let task_context = database.data.context.clone();
-        tokio::task::spawn_blocking(move || {
-            KvTransaction::execute(&task_context, |tx| {
-                execute_set_operation(
-                    namespace,
-                    key,
-                    self.value,
-                    self.expiration,
-                    false,
-                    None,
-                    false,
-                    tx,
-                )
+        database
+            .execute_key_operation(KeyOperation {
+                namespace,
+                key,
+                command: Command::Set(SetCommand {
+                    value: self.value,
+                    expiration: self.expiration,
+                    keep_existing_expiration: false,
+                    check: None,
+                    return_previous_value: false,
+                }),
             })
-        })
-        .await
-        .unwrap()
-        .map(|_| {})
+            .await?;
+        Ok(())
     }
 }
 
@@ -61,45 +57,17 @@ impl KeyValue for Database {
         &self,
         op: KeyOperation,
     ) -> Result<Output, bonsaidb_core::Error> {
-        let task_context = self.data.context.clone();
-        tokio::task::spawn_blocking(move || match op.command {
-            Command::Set {
-                value,
-                expiration,
-                keep_existing_expiration,
-                check,
-                return_previous_value,
-            } => KvTransaction::execute(&task_context, |tx| {
-                execute_set_operation(
-                    op.namespace,
-                    op.key,
-                    value,
-                    expiration,
-                    keep_existing_expiration,
-                    check,
-                    return_previous_value,
-                    tx,
-                )
-            }),
-            Command::Get { delete } => {
-                execute_get_operation(op.namespace, op.key, delete, &task_context)
-            }
-            Command::Delete => KvTransaction::execute(&task_context, |tx| {
-                execute_delete_operation(op.namespace, op.key, tx)
-            }),
-            Command::Increment { amount, saturating } => {
-                KvTransaction::execute(&task_context, |tx| {
-                    execute_increment_operation(op.namespace, op.key, tx, &amount, saturating)
-                })
-            }
-            Command::Decrement { amount, saturating } => {
-                KvTransaction::execute(&task_context, |tx| {
-                    execute_decrement_operation(op.namespace, op.key, tx, &amount, saturating)
-                })
-            }
-        })
-        .await
-        .unwrap()
+        let (result_sender, result_receiver) = flume::bounded(1);
+        self.data
+            .context
+            .kv_operation_sender
+            .send((ManagerOp::Op(op), result_sender))
+            .unwrap();
+        result_receiver
+            .recv_async()
+            .await
+            .unwrap()
+            .map_err(bonsaidb_core::Error::from)
     }
 }
 
@@ -163,204 +131,6 @@ fn split_key(full_key: &str) -> Option<(Option<String>, String)> {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn execute_set_operation(
-    namespace: Option<String>,
-    key: String,
-    value: Value,
-    expiration: Option<Timestamp>,
-    keep_existing_expiration: bool,
-    check: Option<KeyCheck>,
-    return_previous_value: bool,
-    tx: &mut KvTransaction<'_, Context>,
-) -> Result<Output, bonsaidb_core::Error> {
-    let mut entry = Entry { value, expiration };
-    let mut inserted = false;
-    let mut updated = false;
-    let full_key = full_key(namespace.as_deref(), &key);
-    let previous_value = fetch_and_update_no_copy(tx, namespace, key, |existing_value| {
-        let should_update = match check {
-            Some(KeyCheck::OnlyIfPresent) => existing_value.is_some(),
-            Some(KeyCheck::OnlyIfVacant) => existing_value.is_none(),
-            None => true,
-        };
-        if should_update {
-            updated = true;
-            inserted = existing_value.is_none();
-            if keep_existing_expiration && !inserted {
-                if let Ok(previous_entry) = bincode::deserialize::<Entry>(&existing_value.unwrap())
-                {
-                    entry.expiration = previous_entry.expiration;
-                }
-            }
-            let entry_vec = bincode::serialize(&entry).unwrap();
-            Some(Buffer::from(entry_vec))
-        } else {
-            existing_value
-        }
-    })
-    .map_err(Error::from)?;
-
-    if updated {
-        tx.context.update_key_expiration(full_key, entry.expiration);
-        if return_previous_value {
-            if let Some(Ok(entry)) = previous_value.map(|v| bincode::deserialize::<Entry>(&v)) {
-                Ok(Output::Value(Some(entry.value)))
-            } else {
-                Ok(Output::Value(None))
-            }
-        } else if inserted {
-            Ok(Output::Status(KeyStatus::Inserted))
-        } else {
-            Ok(Output::Status(KeyStatus::Updated))
-        }
-    } else {
-        Ok(Output::Status(KeyStatus::NotChanged))
-    }
-}
-
-fn execute_get_operation(
-    namespace: Option<String>,
-    key: String,
-    delete: bool,
-    db: &Context,
-) -> Result<Output, bonsaidb_core::Error> {
-    let tree = db
-        .roots
-        .tree(Unversioned::tree(KEY_TREE))
-        .map_err(Error::from)?;
-    let full_key = full_key(namespace.as_deref(), &key);
-    let entry = if delete {
-        let entry = KvTransaction::execute(db, |tx| {
-            if let Some(removed_entry) =
-                tx.tree().remove(full_key.as_bytes()).map_err(Error::from)?
-            {
-                tx.push(ChangedKey {
-                    namespace,
-                    key,
-                    deleted: true,
-                });
-                Ok(Some(removed_entry))
-            } else {
-                Ok(None)
-            }
-        })?;
-        if entry.is_some() {
-            db.update_key_expiration(full_key, None);
-        }
-        entry
-    } else {
-        tree.get(full_key.as_bytes()).map_err(Error::from)?
-    };
-
-    let entry = entry
-        .map(|e| bincode::deserialize::<Entry>(&e))
-        .transpose()
-        .map_err(Error::from)
-        .unwrap()
-        .map(|e| e.value);
-    Ok(Output::Value(entry))
-}
-
-fn execute_delete_operation(
-    namespace: Option<String>,
-    key: String,
-    tx: &mut KvTransaction<'_, Context>,
-) -> Result<Output, bonsaidb_core::Error> {
-    let full_key = full_key(namespace.as_deref(), &key);
-    let value = tx.tree().remove(full_key.as_bytes()).map_err(Error::from)?;
-    if value.is_some() {
-        tx.push(ChangedKey {
-            namespace,
-            key,
-            deleted: true,
-        });
-        tx.context.update_key_expiration(full_key, None);
-
-        Ok(Output::Status(KeyStatus::Deleted))
-    } else {
-        Ok(Output::Status(KeyStatus::NotChanged))
-    }
-}
-
-fn execute_increment_operation(
-    namespace: Option<String>,
-    key: String,
-    tx: &mut KvTransaction<'_, Context>,
-    amount: &Numeric,
-    saturating: bool,
-) -> Result<Output, bonsaidb_core::Error> {
-    execute_numeric_operation(namespace, key, tx, amount, saturating, increment)
-}
-
-fn execute_decrement_operation(
-    namespace: Option<String>,
-    key: String,
-    tx: &mut KvTransaction<'_, Context>,
-    amount: &Numeric,
-    saturating: bool,
-) -> Result<Output, bonsaidb_core::Error> {
-    execute_numeric_operation(namespace, key, tx, amount, saturating, decrement)
-}
-
-fn execute_numeric_operation<F: Fn(&Numeric, &Numeric, bool) -> Numeric>(
-    namespace: Option<String>,
-    key: String,
-    tx: &mut KvTransaction<'_, Context>,
-    amount: &Numeric,
-    saturating: bool,
-    op: F,
-) -> Result<Output, bonsaidb_core::Error> {
-    let full_key = full_key(namespace.as_deref(), &key);
-    let mut current = tx.tree().get(full_key.as_bytes()).map_err(Error::from)?;
-    loop {
-        let mut entry = current
-            .as_ref()
-            .map(|current| bincode::deserialize::<Entry>(current))
-            .transpose()
-            .map_err(Error::from)?
-            .unwrap_or(Entry {
-                value: Value::Numeric(Numeric::UnsignedInteger(0)),
-                expiration: None,
-            });
-
-        match entry.value {
-            Value::Numeric(existing) => {
-                let value = Value::Numeric(op(&existing, amount, saturating));
-                entry.value = value.clone();
-
-                let result_bytes = Buffer::from(bincode::serialize(&entry).unwrap());
-                match tx.tree().compare_and_swap(
-                    full_key.as_bytes(),
-                    current.as_ref(),
-                    Some(result_bytes),
-                ) {
-                    Ok(_) => {
-                        tx.push(ChangedKey {
-                            namespace,
-                            key,
-                            deleted: false,
-                        });
-                        return Ok(Output::Value(Some(value)));
-                    }
-                    Err(CompareAndSwapError::Conflict(cur)) => {
-                        current = cur;
-                    }
-                    Err(CompareAndSwapError::Error(other)) => {
-                        // TODO should roots errors be able to be put in core?
-                        return Err(bonsaidb_core::Error::Database(other.to_string()));
-                    }
-                }
-            }
-            Value::Bytes(_) => {
-                return Err(bonsaidb_core::Error::Database(String::from(
-                    "type of stored `Value` is not `Numeric`",
-                )))
-            }
-        }
-    }
-}
-
 fn increment(existing: &Numeric, amount: &Numeric, saturating: bool) -> Numeric {
     match amount {
         Numeric::Integer(amount) => {
@@ -417,148 +187,342 @@ fn decrement(existing: &Numeric, amount: &Numeric, saturating: bool) -> Numeric 
     }
 }
 
-fn fetch_and_update_no_copy<F>(
-    tx: &mut KvTransaction<'_, Context>,
-    namespace: Option<String>,
-    key: String,
-    mut f: F,
-) -> Result<Option<Buffer<'static>>, nebari::Error>
-where
-    F: FnMut(Option<Buffer<'static>>) -> Option<Buffer<'static>>,
-{
-    let full_key = full_key(namespace.as_deref(), &key);
-    let mut current = tx.tree().get(full_key.as_bytes())?;
+#[derive(Debug)]
+pub struct ExpirationUpdate {
+    pub tree_key: String,
+    pub expiration: Option<Timestamp>,
+}
 
-    loop {
-        let next = f(current.clone());
-        match tx
-            .tree()
-            .compare_and_swap(full_key.as_bytes(), current.as_ref(), next)
-        {
-            Ok(()) => {
-                tx.push(ChangedKey {
-                    namespace,
-                    key,
-                    deleted: false,
-                });
-                return Ok(current);
-            }
-            Err(CompareAndSwapError::Conflict(cur)) => {
-                current = cur;
-            }
-            Err(CompareAndSwapError::Error(other)) => return Err(other),
+impl ExpirationUpdate {
+    pub fn new(tree_key: String, expiration: Option<Timestamp>) -> Self {
+        Self {
+            tree_key,
+            expiration,
         }
     }
 }
 
 #[derive(Debug)]
-pub struct ExpirationUpdate {
-    pub tree_key: String,
-    pub expiration: Option<Timestamp>,
-    completion_sender: flume::Sender<()>,
-}
-
-impl ExpirationUpdate {
-    pub fn new(tree_key: String, expiration: Option<Timestamp>) -> (Self, flume::Receiver<()>) {
-        let (completion_sender, completion_receiver) = flume::bounded(1);
-        (
-            Self {
-                tree_key,
-                expiration,
-                completion_sender,
-            },
-            completion_receiver,
-        )
-    }
-}
-
-impl Drop for ExpirationUpdate {
-    fn drop(&mut self) {
-        let _ = self.completion_sender.send(());
-    }
-}
-
-async fn remove_expired_keys(
-    roots: &Roots<StdFile>,
-    now: Timestamp,
-    tracked_keys: &mut HashMap<String, Timestamp>,
-    expiration_order: &mut VecDeque<String>,
-) -> Result<(), Error> {
-    let mut keys_to_remove = Vec::new();
-    while !expiration_order.is_empty() && tracked_keys.get(&expiration_order[0]).unwrap() <= &now {
-        let key = expiration_order.pop_front().unwrap();
-        tracked_keys.remove(&key);
-        keys_to_remove.push(key);
-    }
-    let task_roots = roots.clone();
-    tokio::task::spawn_blocking(move || {
-        KvTransaction::execute(&task_roots, |tx| {
-            for full_key in keys_to_remove {
-                if let Some((namespace, key)) = split_key(&full_key) {
-                    tx.tree().remove(full_key.as_bytes()).map_err(Error::from)?;
-
-                    tx.push(ChangedKey {
-                        namespace,
-                        key,
-                        deleted: true,
-                    });
-                }
-            }
-            Ok(())
-        })?;
-
-        Result::<(), Error>::Ok(())
-    })
-    .await
-    .unwrap()?;
-    Ok(())
-}
-
-pub(crate) async fn expiration_task(
+pub(super) struct KeyValueManager {
+    operation_receiver: flume::Receiver<(
+        ManagerOp,
+        flume::Sender<Result<Output, bonsaidb_core::Error>>,
+    )>,
     roots: Roots<StdFile>,
-    updates: flume::Receiver<ExpirationUpdate>,
-) -> Result<(), Error> {
-    // expiring_keys will be maintained such that the soonest expiration is at the front and furthest in the future is at the back
-    let mut tracked_keys = HashMap::new();
-    let mut expiration_order = VecDeque::new();
-    loop {
-        let update = if expiration_order.is_empty() {
-            match updates.recv_async().await {
-                Ok(update) => update,
-                Err(_) => break,
-            }
-        } else {
-            // Check to see if we have any remaining time before a key expires
-            let timeout = tracked_keys.get(&expiration_order[0]).unwrap();
-            let now = Timestamp::now();
-            let remaining_time = *timeout - now;
-            let received_update = if let Some(remaining_time) = remaining_time {
-                // Allow flume to receive updates for the remaining time.
-                match tokio::time::timeout(remaining_time, updates.recv_async()).await {
-                    Ok(Ok(update)) => Some(update),
-                    Ok(Err(flume::RecvError::Disconnected)) => break,
-                    Err(_elapsed) => None,
+    pending_expiration_updates: Vec<ExpirationUpdate>,
+    expiring_keys: HashMap<String, Timestamp>,
+    expiration_order: VecDeque<String>,
+    dirty_keys: HashMap<String, Option<Buffer<'static>>>,
+}
+
+#[derive(Debug)]
+pub(super) enum ManagerOp {
+    Op(KeyOperation),
+    SetExpiration(ExpirationUpdate),
+}
+
+impl KeyValueManager {
+    pub fn new(
+        operation_receiver: flume::Receiver<(
+            ManagerOp,
+            flume::Sender<Result<Output, bonsaidb_core::Error>>,
+        )>,
+        roots: Roots<StdFile>,
+    ) -> Self {
+        Self {
+            operation_receiver,
+            roots,
+            pending_expiration_updates: Vec::new(),
+            expiring_keys: HashMap::new(),
+            expiration_order: VecDeque::new(),
+            dirty_keys: HashMap::new(),
+        }
+    }
+
+    pub async fn run(&mut self) -> Result<(), Error> {
+        while let Some((op, result_sender)) = self.wait_for_next_operation().await? {
+            let result = match dbg!(op) {
+                ManagerOp::Op(op) => match op.command {
+                    Command::Set(command) => {
+                        self.execute_set_operation(op.namespace.as_deref(), &op.key, command)
+                    }
+                    Command::Get { delete } => {
+                        self.execute_get_operation(op.namespace.as_deref(), &op.key, delete)
+                    }
+                    Command::Delete => {
+                        self.execute_delete_operation(op.namespace.as_deref(), &op.key)
+                    }
+                    Command::Increment { amount, saturating } => self.execute_increment_operation(
+                        op.namespace.as_deref(),
+                        &op.key,
+                        &amount,
+                        saturating,
+                    ),
+                    Command::Decrement { amount, saturating } => self.execute_decrement_operation(
+                        op.namespace.as_deref(),
+                        &op.key,
+                        &amount,
+                        saturating,
+                    ),
+                },
+                ManagerOp::SetExpiration(expiration) => {
+                    self.pending_expiration_updates.push(expiration);
+                    Ok(Output::Status(KeyStatus::Updated))
                 }
-            } else {
-                updates.try_recv().ok()
             };
 
-            // If we've received an update, we bubble it up to process
-            if let Some(update) = received_update {
-                update
+            println!("After op: {:?}", self.pending_expiration_updates);
+            self.process_pending_expiration_updates();
+            println!("After processing pending: {:?}", self.expiring_keys);
+            self.remove_expired_keys(Timestamp::now());
+            println!("After removing expired: {:?}", self.dirty_keys);
+            self.commit_dirty_keys().await?;
+            println!("After committing: {:?}", self.expiring_keys);
+
+            drop(result_sender.send(result));
+        }
+        Ok(())
+    }
+
+    fn execute_set_operation(
+        &mut self,
+        namespace: Option<&str>,
+        key: &str,
+        set: SetCommand,
+    ) -> Result<Output, bonsaidb_core::Error> {
+        let mut entry = Entry {
+            value: set.value,
+            expiration: set.expiration,
+        };
+        let mut inserted = false;
+        let mut updated = false;
+        let full_key = full_key(namespace, key);
+        let previous_value = self
+            .fetch_and_update_no_copy(&full_key, |existing_value| {
+                let should_update = match set.check {
+                    Some(KeyCheck::OnlyIfPresent) => existing_value.is_some(),
+                    Some(KeyCheck::OnlyIfVacant) => existing_value.is_none(),
+                    None => true,
+                };
+                if should_update {
+                    updated = true;
+                    inserted = existing_value.is_none();
+                    if set.keep_existing_expiration && !inserted {
+                        if let Ok(previous_entry) =
+                            bincode::deserialize::<Entry>(&existing_value.unwrap())
+                        {
+                            entry.expiration = previous_entry.expiration;
+                        }
+                    }
+                    let entry_vec = bincode::serialize(&entry).unwrap();
+                    Some(Buffer::from(entry_vec))
+                } else {
+                    existing_value
+                }
+            })
+            .map_err(Error::from)?;
+
+        if updated {
+            self.update_key_expiration(full_key, entry.expiration);
+            if set.return_previous_value {
+                if let Some(Ok(entry)) = previous_value.map(|v| bincode::deserialize::<Entry>(&v)) {
+                    Ok(Output::Value(Some(entry.value)))
+                } else {
+                    Ok(Output::Value(None))
+                }
+            } else if inserted {
+                Ok(Output::Status(KeyStatus::Inserted))
             } else {
-                // Reaching this block means that we didn't receive an update to
-                // process, and we have at least one key that is ready to be
-                // removed.
-                remove_expired_keys(&roots, now, &mut tracked_keys, &mut expiration_order).await?;
-                continue;
+                Ok(Output::Status(KeyStatus::Updated))
             }
+        } else {
+            Ok(Output::Status(KeyStatus::NotChanged))
+        }
+    }
+
+    fn update_key_expiration(&mut self, key: String, expiration: Option<Timestamp>) {
+        let update = ExpirationUpdate::new(key, expiration);
+        self.pending_expiration_updates.push(update);
+    }
+
+    fn execute_get_operation(
+        &mut self,
+        namespace: Option<&str>,
+        key: &str,
+        delete: bool,
+    ) -> Result<Output, bonsaidb_core::Error> {
+        let full_key = full_key(namespace, key);
+        let entry = if delete {
+            self.remove(full_key).map_err(Error::from)?
+        } else {
+            self.get(&full_key).map_err(Error::from)?
         };
 
-        if let Some(expiration) = update.expiration {
-            let key = if tracked_keys.contains_key(&update.tree_key) {
-                // Update the existing entry.
-                let existing_entry_index = expiration_order
+        let entry = entry
+            .map(|e| bincode::deserialize::<Entry>(&e))
+            .transpose()
+            .map_err(Error::from)
+            .unwrap()
+            .map(|e| e.value);
+        Ok(Output::Value(entry))
+    }
+
+    fn execute_delete_operation(
+        &mut self,
+        namespace: Option<&str>,
+        key: &str,
+    ) -> Result<Output, bonsaidb_core::Error> {
+        let full_key = full_key(namespace, key);
+        let value = self.remove(full_key).map_err(Error::from)?;
+        if value.is_some() {
+            Ok(Output::Status(KeyStatus::Deleted))
+        } else {
+            Ok(Output::Status(KeyStatus::NotChanged))
+        }
+    }
+
+    fn execute_increment_operation(
+        &mut self,
+        namespace: Option<&str>,
+        key: &str,
+        amount: &Numeric,
+        saturating: bool,
+    ) -> Result<Output, bonsaidb_core::Error> {
+        self.execute_numeric_operation(namespace, key, amount, saturating, increment)
+    }
+
+    fn execute_decrement_operation(
+        &mut self,
+        namespace: Option<&str>,
+        key: &str,
+        amount: &Numeric,
+        saturating: bool,
+    ) -> Result<Output, bonsaidb_core::Error> {
+        self.execute_numeric_operation(namespace, key, amount, saturating, decrement)
+    }
+
+    fn execute_numeric_operation<F: Fn(&Numeric, &Numeric, bool) -> Numeric>(
+        &mut self,
+        namespace: Option<&str>,
+        key: &str,
+        amount: &Numeric,
+        saturating: bool,
+        op: F,
+    ) -> Result<Output, bonsaidb_core::Error> {
+        let full_key = full_key(namespace, key);
+        let current = self.get(&full_key).map_err(Error::from)?;
+        let mut entry = current
+            .as_ref()
+            .map(|current| bincode::deserialize::<Entry>(current))
+            .transpose()
+            .map_err(Error::from)?
+            .unwrap_or(Entry {
+                value: Value::Numeric(Numeric::UnsignedInteger(0)),
+                expiration: None,
+            });
+
+        match entry.value {
+            Value::Numeric(existing) => {
+                let value = Value::Numeric(op(&existing, amount, saturating));
+                entry.value = value.clone();
+
+                let result_bytes = Buffer::from(bincode::serialize(&entry).unwrap());
+                self.set(full_key, result_bytes);
+                Ok(Output::Value(Some(value)))
+            }
+            Value::Bytes(_) => Err(bonsaidb_core::Error::Database(String::from(
+                "type of stored `Value` is not `Numeric`",
+            ))),
+        }
+    }
+
+    fn fetch_and_update_no_copy<F>(
+        &mut self,
+        full_key: &str,
+        mut f: F,
+    ) -> Result<Option<Buffer<'static>>, nebari::Error>
+    where
+        F: FnMut(Option<Buffer<'static>>) -> Option<Buffer<'static>>,
+    {
+        let current = self.get(full_key)?;
+        let next = f(current.clone());
+        if let Some(entry) = self.dirty_keys.get_mut(full_key) {
+            *entry = next;
+        } else {
+            self.dirty_keys.insert(full_key.to_string(), next);
+        }
+        Ok(current)
+    }
+
+    fn remove(&mut self, key: String) -> Result<Option<Buffer<'static>>, nebari::Error> {
+        self.update_key_expiration(key.clone(), None);
+
+        if let Some(dirty_entry) = self.dirty_keys.get_mut(&key) {
+            Ok(dirty_entry.take())
+        } else {
+            // There might be a value on-disk we need to remove.
+            let previous_value = self
+                .roots
+                .tree(Unversioned::tree(KEY_TREE))?
+                .get(key.as_bytes())?;
+            self.dirty_keys.insert(key, None);
+            Ok(previous_value)
+        }
+    }
+
+    fn get(&self, key: &str) -> Result<Option<Buffer<'static>>, nebari::Error> {
+        if let Some(entry) = self.dirty_keys.get(key) {
+            Ok(entry.clone())
+        } else {
+            self.roots
+                .tree(Unversioned::tree(KEY_TREE))?
+                .get(key.as_bytes())
+        }
+    }
+
+    fn set(&mut self, key: String, value: Buffer<'static>) {
+        self.dirty_keys.insert(key, Some(value));
+    }
+
+    fn process_pending_expiration_updates(&mut self) {
+        for update in self.pending_expiration_updates.drain(..) {
+            if let Some(expiration) = update.expiration {
+                let key = if self.expiring_keys.contains_key(&update.tree_key) {
+                    // Update the existing entry.
+                    let existing_entry_index = self
+                        .expiration_order
+                        .iter()
+                        .enumerate()
+                        .find_map(|(index, key)| {
+                            if &update.tree_key == key {
+                                Some(index)
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap();
+                    self.expiration_order.remove(existing_entry_index).unwrap()
+                } else {
+                    update.tree_key.clone()
+                };
+
+                // Insert the key into the expiration_order queue
+                let mut insert_at = None;
+                for (index, expiring_key) in self.expiration_order.iter().enumerate() {
+                    if self.expiring_keys.get(expiring_key).unwrap() > &expiration {
+                        insert_at = Some(index);
+                        break;
+                    }
+                }
+                if let Some(insert_at) = insert_at {
+                    self.expiration_order.insert(insert_at, key.clone());
+                } else {
+                    self.expiration_order.push_back(key.clone());
+                }
+                self.expiring_keys.insert(key, expiration);
+            } else if self.expiring_keys.remove(&update.tree_key).is_some() {
+                let index = self
+                    .expiration_order
                     .iter()
                     .enumerate()
                     .find_map(|(index, key)| {
@@ -569,94 +533,214 @@ pub(crate) async fn expiration_task(
                         }
                     })
                     .unwrap();
-                expiration_order.remove(existing_entry_index).unwrap()
-            } else {
-                update.tree_key.clone()
-            };
-
-            // Insert the key into the expiration_order queue
-            let mut insert_at = None;
-            for (index, expiring_key) in expiration_order.iter().enumerate() {
-                if tracked_keys.get(expiring_key).unwrap() > &expiration {
-                    insert_at = Some(index);
-                    break;
-                }
+                self.expiration_order.remove(index);
             }
-            if let Some(insert_at) = insert_at {
-                expiration_order.insert(insert_at, key.clone());
-            } else {
-                expiration_order.push_back(key.clone());
-            }
-            tracked_keys.insert(key, expiration);
-        } else if tracked_keys.remove(&update.tree_key).is_some() {
-            let index = expiration_order
-                .iter()
-                .enumerate()
-                .find_map(|(index, key)| {
-                    if &update.tree_key == key {
-                        Some(index)
-                    } else {
-                        None
-                    }
-                })
-                .unwrap();
-            expiration_order.remove(index);
         }
     }
 
-    Ok(())
-}
+    async fn wait_for_next_operation(
+        &mut self,
+    ) -> Result<
+        Option<(
+            ManagerOp,
+            flume::Sender<Result<Output, bonsaidb_core::Error>>,
+        )>,
+        Error,
+    > {
+        loop {
+            if self.expiration_order.is_empty() {
+                match self.operation_receiver.recv_async().await {
+                    Ok(update) => return Ok(Some(update)),
+                    Err(_) => break,
+                }
+            }
 
-struct KvTransaction<'context, C> {
-    context: &'context C,
-    transaction: ExecutingTransaction<StdFile>,
-    changed_keys: Vec<ChangedKey>,
-}
+            // Check to see if we have any remaining time before a key expires
+            let timeout = self.expiring_keys.get(&self.expiration_order[0]).unwrap();
+            let now = Timestamp::now();
+            let remaining_time = *timeout - now;
+            let received_update = if let Some(remaining_time) = remaining_time {
+                // Allow flume to receive updates for the remaining time.
+                match tokio::time::timeout(remaining_time, self.operation_receiver.recv_async())
+                    .await
+                {
+                    Ok(Ok(update)) => Some(update),
+                    Ok(Err(flume::RecvError::Disconnected)) => break,
+                    Err(_elapsed) => None,
+                }
+            } else {
+                self.operation_receiver.try_recv().ok()
+            };
 
-impl<'context, C> KvTransaction<'context, C>
-where
-    C: Borrow<Roots<StdFile>>,
-{
-    pub fn execute<T, F: FnOnce(&mut Self) -> Result<T, bonsaidb_core::Error>>(
-        context: &'context C,
-        tx_body: F,
-    ) -> Result<T, bonsaidb_core::Error> {
-        let transaction = context
-            .borrow()
+            // If we've received an update, we bubble it up to process
+            if let Some(update) = received_update {
+                return Ok(Some(update));
+            }
+
+            // Reaching this block means that we didn't receive an update to
+            // process, and we have at least one key that is ready to be
+            // removed.
+            if self.remove_expired_keys(now) {
+                self.commit_dirty_keys().await?;
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn remove_expired_keys(&mut self, now: Timestamp) -> bool {
+        let mut removed_at_least_one = false;
+
+        while !self.expiration_order.is_empty()
+            && self.expiring_keys.get(&self.expiration_order[0]).unwrap() <= &now
+        {
+            removed_at_least_one = true;
+
+            let key = self.expiration_order.pop_front().unwrap();
+            self.expiring_keys.remove(&key);
+            println!("Removing expired key: {}", key);
+            self.dirty_keys.insert(key, None);
+        }
+
+        removed_at_least_one
+    }
+
+    async fn commit_dirty_keys(&mut self) -> Result<(), bonsaidb_core::Error> {
+        if self.dirty_keys.is_empty() {
+            Ok(())
+        } else {
+            let roots = self.roots.clone();
+            let keys = self.dirty_keys.drain().collect();
+            tokio::task::spawn_blocking(move || Self::persist_keys(&roots, keys))
+                .await
+                .unwrap()
+        }
+    }
+
+    fn persist_keys(
+        roots: &Roots<StdFile>,
+        keys: Vec<(String, Option<Buffer<'static>>)>,
+    ) -> Result<(), bonsaidb_core::Error> {
+        let transaction = roots
             .transaction(&[Unversioned::tree(KEY_TREE)])
             .map_err(Error::from)?;
-        let mut tx = Self {
-            context,
+        let mut tx = KvTransaction {
             transaction,
             changed_keys: Vec::new(),
         };
 
-        match tx_body(&mut tx) {
-            Ok(result) => {
-                let Self {
-                    mut transaction,
-                    changed_keys,
-                    ..
-                } = tx;
-                if !changed_keys.is_empty() {
-                    transaction
-                        .entry_mut()
-                        .set_data(pot::to_vec(&Changes::Keys(changed_keys))?)
-                        .map_err(Error::from)?;
-                    transaction.commit().map_err(Error::from)?;
-                }
-                Ok(result)
-            }
-            Err(err) => Err(bonsaidb_core::Error::from(Error::from(err))),
-        }
-    }
+        for (full_key, value) in keys {
+            let (namespace, key) = split_key(&full_key).unwrap();
+            let (changed, deleted) = if let Some(value) = value {
+                tx.tree()
+                    .set(full_key.into_bytes(), value)
+                    .map_err(Error::from)?;
+                (true, false)
+            } else {
+                let removed = tx
+                    .tree()
+                    .remove(full_key.as_bytes())
+                    .map_err(Error::from)?
+                    .is_some();
+                (removed, true)
+            };
 
+            if changed {
+                tx.push(ChangedKey {
+                    namespace,
+                    key,
+                    deleted,
+                });
+            }
+        }
+
+        let KvTransaction {
+            mut transaction,
+            changed_keys,
+            ..
+        } = tx;
+        if !changed_keys.is_empty() {
+            transaction
+                .entry_mut()
+                .set_data(pot::to_vec(&Changes::Keys(changed_keys))?)
+                .map_err(Error::from)?;
+            transaction.commit().map_err(Error::from)?;
+        }
+
+        Ok(())
+    }
+}
+
+struct KvTransaction {
+    transaction: ExecutingTransaction<StdFile>,
+    changed_keys: Vec<ChangedKey>,
+}
+
+impl KvTransaction {
     pub fn push(&mut self, key: ChangedKey) {
         self.changed_keys.push(key);
     }
 
     pub fn tree(&mut self) -> &mut TransactionTree<Unversioned, StdFile> {
         self.transaction.tree(0).unwrap()
+    }
+}
+
+#[derive(Debug)]
+pub struct ExpirationLoader {
+    pub database: Database,
+}
+
+#[async_trait]
+impl Job for ExpirationLoader {
+    type Output = ();
+    type Error = Error;
+
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    async fn execute(&mut self) -> Result<Self::Output, Self::Error> {
+        let database = self.database.clone();
+        let (sender, receiver) = flume::unbounded();
+
+        tokio::task::spawn_blocking(move || {
+            // Find all trees that start with <database>.kv.
+            let keep_scanning = AtomicBool::new(true);
+            database
+                .roots()
+                .tree(Unversioned::tree(KEY_TREE))?
+                .scan::<Infallible, _, _, _, _>(
+                    ..,
+                    true,
+                    |_, _, _| true,
+                    |_, _| {
+                        if keep_scanning.load(Ordering::SeqCst) {
+                            KeyEvaluation::ReadData
+                        } else {
+                            KeyEvaluation::Stop
+                        }
+                    },
+                    |key, _, entry: Buffer<'static>| {
+                        if let Ok(entry) = bincode::deserialize::<Entry>(&entry) {
+                            if entry.expiration.is_some()
+                                && sender.send((key, entry.expiration)).is_err()
+                            {
+                                keep_scanning.store(false, Ordering::SeqCst);
+                            }
+                        }
+
+                        Ok(())
+                    },
+                )?;
+
+            Result::<(), Error>::Ok(())
+        });
+
+        while let Ok((key, expiration)) = receiver.recv_async().await {
+            self.database
+                .update_key_expiration_async(String::from_utf8(key.to_vec())?, expiration)
+                .await;
+        }
+
+        Ok(())
     }
 }
 
@@ -861,63 +945,5 @@ mod tests {
             Ok(())
         })
         .await
-    }
-}
-
-#[derive(Debug)]
-pub struct ExpirationLoader {
-    pub database: Database,
-}
-
-#[async_trait]
-impl Job for ExpirationLoader {
-    type Output = ();
-    type Error = Error;
-
-    #[cfg_attr(feature = "tracing", tracing::instrument)]
-    async fn execute(&mut self) -> Result<Self::Output, Self::Error> {
-        let database = self.database.clone();
-        let (sender, receiver) = flume::unbounded();
-
-        tokio::task::spawn_blocking(move || {
-            // Find all trees that start with <database>.kv.
-            let keep_scanning = AtomicBool::new(true);
-            database
-                .roots()
-                .tree(Unversioned::tree(KEY_TREE))?
-                .scan::<Infallible, _, _, _, _>(
-                    ..,
-                    true,
-                    |_, _, _| true,
-                    |_, _| {
-                        if keep_scanning.load(Ordering::SeqCst) {
-                            KeyEvaluation::ReadData
-                        } else {
-                            KeyEvaluation::Stop
-                        }
-                    },
-                    |key, _, entry: Buffer<'static>| {
-                        if let Ok(entry) = bincode::deserialize::<Entry>(&entry) {
-                            if entry.expiration.is_some()
-                                && sender.send((key, entry.expiration)).is_err()
-                            {
-                                keep_scanning.store(false, Ordering::SeqCst);
-                            }
-                        }
-
-                        Ok(())
-                    },
-                )?;
-
-            Result::<(), Error>::Ok(())
-        });
-
-        while let Ok((key, expiration)) = receiver.recv_async().await {
-            self.database
-                .update_key_expiration_async(String::from_utf8(key.to_vec())?, expiration)
-                .await;
-        }
-
-        Ok(())
     }
 }

--- a/crates/bonsaidb-local/src/error.rs
+++ b/crates/bonsaidb-local/src/error.rs
@@ -22,9 +22,9 @@ pub enum Error {
     #[error("error while serializing: {0}")]
     Serialization(#[from] pot::Error),
 
-    /// An internal error occurred while waiting for a message.
-    #[error("error while waiting for a message: {0}")]
-    InternalCommunication(#[from] flume::RecvError),
+    /// An internal error occurred while waiting for or sending a message.
+    #[error("error while communicating internally")]
+    InternalCommunication,
 
     /// An error occurred while executing a view
     #[error("error from view: {0}")]
@@ -59,6 +59,18 @@ pub enum Error {
     /// An error occurred from backing up or restoring.
     #[error("a backup error: {0}")]
     Backup(Box<dyn AnyError>),
+}
+
+impl From<flume::RecvError> for Error {
+    fn from(_: flume::RecvError) -> Self {
+        Self::InternalCommunication
+    }
+}
+
+impl Error {
+    pub(crate) fn from_send<T>(_: flume::SendError<T>) -> Self {
+        Self::InternalCommunication
+    }
 }
 
 impl From<Error> for bonsaidb_core::Error {

--- a/crates/bonsaidb-server/src/config.rs
+++ b/crates/bonsaidb-server/src/config.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 #[cfg(feature = "encryption")]
 use bonsaidb_core::document::KeyId;
 use bonsaidb_core::{permissions::Permissions, schema::Schema};
-use bonsaidb_local::config::{Builder, StorageConfiguration};
+use bonsaidb_local::config::{Builder, KeyValuePersistence, StorageConfiguration};
 #[cfg(feature = "encryption")]
 use bonsaidb_local::vault::AnyVaultKeyStorage;
 
@@ -190,6 +190,11 @@ impl Builder for ServerConfiguration {
 
     fn check_view_integrity_on_open(mut self, check: bool) -> Self {
         self.storage.views.check_integrity_on_open = check;
+        self
+    }
+
+    fn key_value_persistence(mut self, persistence: KeyValuePersistence) -> Self {
+        self.storage.key_value_persistence = persistence;
         self
     }
 }


### PR DESCRIPTION
Closes #120.

- [x] Introduce new background task that keeps changed keys in memory before persisting to disk
- [x] Add configuration for how often to commit keys
- [x] Test various configurations
- [x] Switch to multi-ops for committing keys