### PR TITLE
Enabling doc_auto_cfg to show feature flags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Generate Docs
         run: |
           cargo doc --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
 
       - name: Deploy Docs
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' || github.event.ref_type == 'tag'

--- a/crates/bonsaidb-client/Cargo.toml
+++ b/crates/bonsaidb-client/Cargo.toml
@@ -65,3 +65,4 @@ tokio = { version = "1", features = ["sync", "macros"] }
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]

--- a/crates/bonsaidb-client/src/lib.rs
+++ b/crates/bonsaidb-client/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::missing_errors_doc, // TODO clippy::missing_errors_doc
     clippy::option_if_let_else,
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use url;
 

--- a/crates/bonsaidb-core/Cargo.toml
+++ b/crates/bonsaidb-core/Cargo.toml
@@ -53,3 +53,4 @@ anyhow = "1"
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]

--- a/crates/bonsaidb-core/src/lib.rs
+++ b/crates/bonsaidb-core/src/lib.rs
@@ -15,6 +15,8 @@
     clippy::option_if_let_else,
     clippy::module_name_repetitions,
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// Types for creating and validating permissions.
 pub mod permissions;

--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -81,3 +81,4 @@ anyhow = "1"
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]

--- a/crates/bonsaidb-local/src/lib.rs
+++ b/crates/bonsaidb-local/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::option_if_let_else,
     clippy::module_name_repetitions,
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// Command-line interface helpers.
 #[cfg(feature = "cli")]

--- a/crates/bonsaidb-server/Cargo.toml
+++ b/crates/bonsaidb-server/Cargo.toml
@@ -83,3 +83,4 @@ anyhow = "1"
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]

--- a/crates/bonsaidb-server/src/lib.rs
+++ b/crates/bonsaidb-server/src/lib.rs
@@ -16,6 +16,8 @@
     clippy::option_if_let_else,
     clippy::module_name_repetitions,
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod backend;
 /// Command-line interface for the server.

--- a/crates/bonsaidb/Cargo.toml
+++ b/crates/bonsaidb/Cargo.toml
@@ -128,3 +128,4 @@ env_logger = "0.9"
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]

--- a/crates/bonsaidb/src/lib.rs
+++ b/crates/bonsaidb/src/lib.rs
@@ -14,29 +14,26 @@
     clippy::option_if_let_else,
     clippy::multiple_crate_versions, // TODO custodian-password deps + x25119 deps
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "client")]
-#[doc(inline)]
 pub use bonsaidb_client as client;
-#[doc(inline)]
 pub use bonsaidb_core as core;
 #[cfg(feature = "local")]
-#[doc(inline)]
 pub use bonsaidb_local as local;
 #[cfg(feature = "server")]
-#[doc(inline)]
 pub use bonsaidb_server as server;
-#[cfg(all(feature = "client", feature = "server"))]
-mod any_connection;
 #[cfg(feature = "cli")]
 pub mod cli;
 
 /// `VaultKeyStorage` implementors.
 #[cfg(feature = "keystorage-s3")]
 pub mod keystorage {
-    #[cfg(feature = "keystorage-s3")]
-    #[doc(inline)]
     pub use bonsaidb_keystorage_s3 as s3;
 }
+
 #[cfg(all(feature = "client", feature = "server"))]
-pub use any_connection::*;
+mod any_connection;
+#[cfg(all(feature = "client", feature = "server"))]
+pub use any_connection::{AnyDatabase, AnyServerConnection};


### PR DESCRIPTION
This isn't perfect, but it's better than not having feature flags
showing up at all. #178 explains the vision for where this will end-up
after namespaced feature flags are released, and #174 can introduce a
table of feature flags for each crate and link to #178.