### PR TITLE
Add lz4 compression support

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          cargo bench --bench suite --features sqlite,redis
+          cargo bench --bench suite --features sqlite,redis,compression
         env:
           COMMERCE_POSTGRESQL_URL: postgres://postgres:postgres@localhost/postgres
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          cargo bench --bench commerce --features postgresql -- --suite -n1000
+          cargo bench --bench commerce --features postgresql,compression -- --suite -n1000
         env:
           COMMERCE_POSTGRESQL_URL: postgres://postgres:postgres@localhost/postgres
 

--- a/.rustme/docs.md
+++ b/.rustme/docs.md
@@ -86,6 +86,7 @@ bonsaidb = { version = "*", default-features = false, features = "local-full" }
   `bonsaidb-local`.
 - `local-cli`: Enables the `clap` structures for embedding database
   management commands into your own command-line interface.
+- `local-compression`: Enables support for compressed storage using lz4.
 - `local-encryption`: Enables at-rest encryption.
 - `local-instrument`: Enables instrumenting with `tracing`.
 - `local-multiuser`: Enables multi-user support.
@@ -104,6 +105,7 @@ bonsaidb = { version = "*", default-features = false, features = "server-full" }
   `bonsaidb-server`.
 - `server-acme`: Enables automtic certificate acquisition through ACME/LetsEncrypt.
 - `server-cli`: Enables the `cli` module.
+- `server-compression`: Enables support for compressed storage using lz4.
 - `server-encryption`: Enables at-rest encryption.
 - `server-hyper`: Enables convenience functions for upgrading websockets using `hyper`.
 - `server-instrument`: Enables instrumenting with `tracing`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `bonsaidb::core::Error::DocumentConflict` now contains a `Header` instead of
   just the document's ID. This allows an application to re-submit an update with
   the updated header without another request to the database.
+- `StorageConfiguratation::vault_key_storage` now uses an `Arc` instead of a
+  `Box`. This change allows `StorageConfiguration` and `ServerConfiguration` to
+  implement `Clone`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   just the document's ID. This allows an application to re-submit an update with
   the updated header without another request to the database.
 
+### Added
+
+- Optional compression is now available, using the LZ4 algorithm.
+  `StorageConfiguration::default_compression` controls the setting. When using
+  the `bonsaidb` crate, the feature can be made available using either
+  `local-compression` or `server-compression`. When using `bonsaidb-server` or
+  `bonsaidb-local` directly, the feature name is `compression`.
+
+  This compression is currently applied on all chunks of data written to
+  BonsaiDb that are larger than a hardcoded threshold. This includes the
+  Key-Value store. The threshold may be configurable in the future.
+
+  Some of the benchmark suite has been expanded to include comparisons between
+  local storage with and without compression.
+
 ## v0.1.2
 
 ### Fixed

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -15,6 +15,7 @@ harness = false
 [features]
 sqlite = ["rusqlite", "sqlx", "sqlx/sqlite"]
 postgresql = ["sqlx", "sqlx/postgres"]
+compression = ["bonsaidb/server-compression", "bonsaidb/local-compression"]
 
 [dependencies]
 redis = { version = "0.21", optional = true, features = ["tokio-comp"] }

--- a/benchmarks/benches/collections/bonsai.rs
+++ b/benchmarks/benches/collections/bonsai.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "compression")]
+use bonsaidb::local::config::Compression;
 use bonsaidb::{
     core::{connection::Connection, test_util::TestDirectory},
     local::{
@@ -17,20 +19,26 @@ async fn save_document(doc: &ResizableDocument, db: &Database) {
         .unwrap();
 }
 
+#[cfg_attr(not(feature = "compression"), allow(unused_mut))]
 pub(super) fn save_documents(group: &mut BenchmarkGroup<WallTime>, doc: &ResizableDocument) {
-    group.bench_function(
-        BenchmarkId::new("bonsaidb-local", doc.data.len().bytes()),
-        |b| {
+    let path = TestDirectory::new("benches-basics.bonsaidb");
+    let mut configs = vec![("bonsaidb-local", StorageConfiguration::new(&path))];
+    #[cfg(feature = "compression")]
+    {
+        configs.push((
+            "bonsaidb-local+lz4",
+            StorageConfiguration::new(&path).default_compression(Compression::Lz4),
+        ))
+    }
+    for (label, config) in configs {
+        group.bench_function(BenchmarkId::new(label, doc.data.len().bytes()), |b| {
             let runtime = tokio::runtime::Runtime::new().unwrap();
-            let path = TestDirectory::new("benches-basics.bonsaidb");
             let db = runtime
-                .block_on(Database::open::<ResizableDocument>(
-                    StorageConfiguration::new(&path),
-                ))
+                .block_on(Database::open::<ResizableDocument>(config.clone()))
                 .unwrap();
             b.to_async(&runtime).iter(|| save_document(doc, &db));
-        },
-    );
+        });
+    }
 
     // TODO bench read performance
     // TODO bench read + write performance (with different numbers of readers/writers)

--- a/benchmarks/benches/collections/mod.rs
+++ b/benchmarks/benches/collections/mod.rs
@@ -1,5 +1,6 @@
 use bonsaidb::core::{arc_bytes::serde::Bytes, schema::Collection};
 use criterion::{Criterion, Throughput};
+use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 
 mod bonsai;
@@ -18,8 +19,9 @@ pub fn save_documents(c: &mut Criterion) {
     // First set of benchmarks tests inserting documents
     let mut group = c.benchmark_group("save_documents");
     for size in [KB, 2 * KB, 8 * KB, 32 * KB, KB * KB] {
+        let mut rng = thread_rng();
         group.throughput(Throughput::Bytes(size as u64));
-        let mut data = Vec::with_capacity(size);
+        let mut data = (0..size).map(|_| rng.gen()).collect::<Vec<_>>();
         data.resize_with(size, || 7u8);
         let doc = ResizableDocument {
             data: Bytes::from(data),

--- a/benchmarks/benches/commerce/execute.rs
+++ b/benchmarks/benches/commerce/execute.rs
@@ -27,7 +27,7 @@ use crate::{
         AddProductToCart, Checkout, CreateCart, FindProduct, Load, LookupProduct, Operation,
         OperationResult, Plan, ReviewProduct, ShopperPlanConfig,
     },
-    plot::{BACKGROUND_COLOR, TEXT_COLOR},
+    plot::{label_to_color, BACKGROUND_COLOR, TEXT_COLOR},
     utils::{current_timestamp_string, local_git_rev},
 };
 
@@ -45,6 +45,19 @@ pub fn execute_plans_for_all_backends(
         println!("Executing bonsaidb-local");
         BonsaiBackend::execute_async(
             Bonsai::Local,
+            plans,
+            initial_data,
+            number_of_agents,
+            measurements,
+        );
+    }
+    if name_filter.is_empty()
+        || name_filter == "bonsaidb"
+        || name_filter.starts_with("bonsaidb-local+lz4")
+    {
+        println!("Executing bonsaidb-local+lz4");
+        BonsaiBackend::execute_async(
+            Bonsai::LocalLz4,
             plans,
             initial_data,
             number_of_agents,
@@ -490,30 +503,6 @@ impl DiscreteRanged for NanosRange {
         Some(Nanos(self.0.start().0 + index as u64))
     }
 }
-
-fn label_to_color(label: &str) -> RGBColor {
-    match label {
-        "bonsaidb-local" => COLORS[0],
-        "bonsaidb-quic" => COLORS[1],
-        "bonsaidb-ws" => COLORS[2],
-        "postgresql" => COLORS[3],
-        "sqlite" => COLORS[4],
-        _ => panic!("Unknown label: {}", label),
-    }
-}
-
-// https://coolors.co/dc0ab4-50e991-00bfa0-3355ff-9b19f5-ffa300-e60049-0bb4ff-e6d800
-const COLORS: [RGBColor; 9] = [
-    RGBColor(220, 10, 180),
-    RGBColor(80, 233, 145),
-    RGBColor(0, 191, 160),
-    RGBColor(51, 85, 255),
-    RGBColor(155, 25, 245),
-    RGBColor(255, 163, 0),
-    RGBColor(230, 0, 73),
-    RGBColor(11, 180, 255),
-    RGBColor(230, 216, 0),
-];
 
 fn stats_thread(
     label: String,

--- a/benchmarks/benches/commerce/plot.rs
+++ b/benchmarks/benches/commerce/plot.rs
@@ -155,6 +155,7 @@ impl DiscreteRanged for NanosRange {
 pub fn label_to_color(label: &str) -> RGBColor {
     match label {
         "bonsaidb-local" => COLORS[0],
+        "bonsaidb-local+lz4" => COLORS[5],
         "bonsaidb-quic" => COLORS[1],
         "bonsaidb-ws" => COLORS[2],
         "postgresql" => COLORS[3],

--- a/crates/bonsaidb-core/src/test_util.rs
+++ b/crates/bonsaidb-core/src/test_util.rs
@@ -1378,14 +1378,19 @@ pub async fn user_management_tests<C: Connection, S: StorageConnection>(
 
     let role = Role::named(format!("role-{}", server_name))
         .push_into(admin)
-        .await?;
+        .await
+        .unwrap();
     let group = PermissionGroup::named(format!("group-{}", server_name))
         .push_into(admin)
-        .await?;
+        .await
+        .unwrap();
 
     // Add the role and group.
-    server.add_permission_group_to_user(user_id, &group).await?;
-    server.add_role_to_user(user_id, &role).await?;
+    server
+        .add_permission_group_to_user(user_id, &group)
+        .await
+        .unwrap();
+    server.add_role_to_user(user_id, &role).await.unwrap();
 
     // Test the results
     {
@@ -1400,8 +1405,9 @@ pub async fn user_management_tests<C: Connection, S: StorageConnection>(
     // Add the same things again (should not do anything). With names this time.
     server
         .add_permission_group_to_user(&username, &group)
-        .await?;
-    server.add_role_to_user(&username, &role).await?;
+        .await
+        .unwrap();
+    server.add_role_to_user(&username, &role).await.unwrap();
     {
         // TODO this is what's failing.
         let user = User::load(&username, admin)
@@ -1415,8 +1421,9 @@ pub async fn user_management_tests<C: Connection, S: StorageConnection>(
     // Remove the group.
     server
         .remove_permission_group_from_user(user_id, &group)
-        .await?;
-    server.remove_role_from_user(user_id, &role).await?;
+        .await
+        .unwrap();
+    server.remove_role_from_user(user_id, &role).await.unwrap();
     {
         let user = User::get(user_id, admin)
             .await

--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -15,7 +15,14 @@ homepage = "https://bonsaidb.io/"
 
 [features]
 default = ["full"]
-full = ["cli", "encryption", "instrument", "multiuser", "password-hashing"]
+full = [
+    "cli",
+    "encryption",
+    "instrument",
+    "multiuser",
+    "password-hashing",
+    "compression",
+]
 cli = ["clap"]
 internal-apis = []
 instrument = ["pot/tracing", "nebari/tracing", "tracing"]
@@ -27,6 +34,7 @@ encryption = [
     "blake3",
     "chacha20poly1305",
 ]
+compression = ["lz4_flex"]
 multiuser = ["bonsaidb-core/multiuser"]
 password-hashing = [
     "argon2",
@@ -73,6 +81,7 @@ async-lock = "2"
 argon2 = { version = "^0.3.3", optional = true, features = ["parallel"] }
 sysinfo = { version = "0.23", default-features = false }
 once_cell = { version = "1", optional = true }
+lz4_flex = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
 bonsaidb-core = { path = "../bonsaidb-core", version = "0.1.1", features = [

--- a/crates/bonsaidb-local/src/database.rs
+++ b/crates/bonsaidb-local/src/database.rs
@@ -43,6 +43,8 @@ use nebari::{
 };
 use tokio::sync::watch;
 
+#[cfg(feature = "encryption")]
+use crate::storage::TreeVault;
 use crate::{
     config::{Builder, KeyValuePersistence, StorageConfiguration},
     database::keyvalue::BackgroundWorkerProcessTarget,
@@ -55,9 +57,6 @@ use crate::{
     },
     Storage,
 };
-
-#[cfg(feature = "encryption")]
-use crate::storage::TreeVault;
 
 pub mod keyvalue;
 

--- a/crates/bonsaidb-local/src/error.rs
+++ b/crates/bonsaidb-local/src/error.rs
@@ -35,6 +35,11 @@ pub enum Error {
     #[cfg(feature = "encryption")]
     Vault(#[from] crate::vault::Error),
 
+    /// An error occurred decompressing a stored value.
+    #[error("a vault error occurred: {0}")]
+    #[cfg(feature = "compression")]
+    Compression(#[from] lz4_flex::block::DecompressError),
+
     /// A collection requested to be encrypted, but encryption is disabled.
     #[error("encryption is disabled, but a collection is requesting encryption")]
     #[cfg(not(feature = "encryption"))]

--- a/crates/bonsaidb-local/src/storage.rs
+++ b/crates/bonsaidb-local/src/storage.rs
@@ -161,7 +161,7 @@ struct Data {
     threadpool: ThreadPool<AnyFile>,
     file_manager: AnyFileManager,
     pub(crate) tasks: TaskManager,
-    schemas: RwLock<HashMap<SchemaName, Box<dyn DatabaseOpener>>>,
+    schemas: RwLock<HashMap<SchemaName, Arc<dyn DatabaseOpener>>>,
     available_databases: RwLock<HashMap<String, SchemaName>>,
     open_roots: Mutex<HashMap<String, Context>>,
     #[cfg(feature = "password-hashing")]
@@ -205,7 +205,7 @@ impl Storage {
         let vault = {
             let vault_key_storage = match configuration.vault_key_storage {
                 Some(storage) => storage,
-                None => Box::new(
+                None => Arc::new(
                     LocalVaultKeyStorage::new(owned_path.join("vault-keys"))
                         .await
                         .map_err(|err| Error::Vault(vault::Error::Initializing(err.to_string())))?,
@@ -396,7 +396,7 @@ impl Storage {
         if schemas
             .insert(
                 DB::schema_name(),
-                Box::new(StorageSchemaOpener::<DB>::new()?),
+                Arc::new(StorageSchemaOpener::<DB>::new()?),
             )
             .is_none()
         {

--- a/crates/bonsaidb-local/src/storage.rs
+++ b/crates/bonsaidb-local/src/storage.rs
@@ -11,6 +11,8 @@ use async_trait::async_trait;
 pub use bonsaidb_core::circulate::Relay;
 #[cfg(feature = "password-hashing")]
 use bonsaidb_core::connection::{Authenticated, Authentication};
+#[cfg(any(feature = "encryption", feature = "compression"))]
+use bonsaidb_core::document::KeyId;
 use bonsaidb_core::{
     admin::{
         self,
@@ -18,7 +20,6 @@ use bonsaidb_core::{
         Admin, ADMIN_DATABASE_NAME,
     },
     connection::{self, Connection, StorageConnection},
-    document::KeyId,
     schema::{Schema, SchemaName, Schematic},
 };
 #[cfg(feature = "multiuser")]
@@ -43,8 +44,10 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
 };
 
+#[cfg(feature = "compression")]
+use crate::config::Compression;
 #[cfg(feature = "encryption")]
-use crate::vault::{self, LocalVaultKeyStorage, TreeVault, Vault};
+use crate::vault::{self, LocalVaultKeyStorage, Vault};
 use crate::{
     config::{KeyValuePersistence, StorageConfiguration},
     database::Context,
@@ -167,6 +170,8 @@ struct Data {
     pub(crate) vault: Arc<Vault>,
     #[cfg(feature = "encryption")]
     default_encryption_key: Option<KeyId>,
+    #[cfg(any(feature = "compression", feature = "encryption"))]
+    tree_vault: Option<TreeVault>,
     pub(crate) key_value_persistence: KeyValuePersistence,
     chunk_cache: ChunkCache,
     pub(crate) check_view_integrity_on_database_open: bool,
@@ -216,6 +221,17 @@ impl Storage {
         let argon = argon::Hasher::new(configuration.argon);
         #[cfg(feature = "encryption")]
         let default_encryption_key = configuration.default_encryption_key;
+        #[cfg(all(feature = "compression", feature = "encryption"))]
+        let tree_vault = TreeVault::new_if_needed(
+            default_encryption_key.clone(),
+            &vault,
+            configuration.default_compression,
+        );
+        #[cfg(all(not(feature = "compression"), feature = "encryption"))]
+        let tree_vault = TreeVault::new_if_needed(default_encryption_key.clone(), &vault);
+        #[cfg(all(feature = "compression", not(feature = "encryption")))]
+        let tree_vault = TreeVault::new_if_needed(configuration.default_compression);
+
         let storage = tokio::task::spawn_blocking::<_, Result<Self, Error>>(move || {
             Ok(Self {
                 data: Arc::new(Data {
@@ -227,6 +243,8 @@ impl Storage {
                     vault,
                     #[cfg(feature = "encryption")]
                     default_encryption_key,
+                    #[cfg(any(feature = "compression", feature = "encryption"))]
+                    tree_vault,
                     path: owned_path,
                     file_manager,
                     chunk_cache: ChunkCache::new(2000, 160_384),
@@ -354,13 +372,19 @@ impl Storage {
     }
 
     #[must_use]
+    #[cfg(any(feature = "encryption", feature = "compression"))]
+    pub(crate) fn tree_vault(&self) -> Option<&TreeVault> {
+        self.data.tree_vault.as_ref()
+    }
+
+    #[must_use]
     #[cfg(feature = "encryption")]
     pub(crate) fn default_encryption_key(&self) -> Option<&KeyId> {
         self.data.default_encryption_key.as_ref()
     }
 
     #[must_use]
-    #[cfg(not(feature = "encryption"))]
+    #[cfg(all(feature = "compression", not(feature = "encryption")))]
     #[allow(clippy::unused_self)]
     pub(crate) fn default_encryption_key(&self) -> Option<&KeyId> {
         None
@@ -384,7 +408,10 @@ impl Storage {
         }
     }
 
-    #[cfg_attr(not(feature = "encryption"), allow(unused_mut))]
+    #[cfg_attr(
+        not(any(feature = "encryption", feature = "compression")),
+        allow(unused_mut)
+    )]
     pub(crate) async fn open_roots(&self, name: &str) -> Result<Context, Error> {
         let mut open_roots = fast_async_lock!(self.data.open_roots);
         if let Some(roots) = open_roots.get(name) {
@@ -397,13 +424,12 @@ impl Storage {
                     .file_manager(task_self.data.file_manager.clone())
                     .cache(task_self.data.chunk_cache.clone())
                     .shared_thread_pool(&task_self.data.threadpool);
-                #[cfg(feature = "encryption")]
-                if let Some(key) = task_self.default_encryption_key() {
-                    config = config.vault(TreeVault {
-                        key: key.clone(),
-                        vault: task_self.vault().clone(),
-                    });
+
+                #[cfg(any(feature = "encryption", feature = "compression"))]
+                if let Some(vault) = task_self.data.tree_vault.clone() {
+                    config = config.vault(vault);
                 }
+
                 config.open().map_err(Error::from)
             })
             .await
@@ -870,5 +896,198 @@ impl Debug for StorageId {
 impl Display for StorageId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(self, f)
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg(any(feature = "compression", feature = "encryption"))]
+pub(crate) struct TreeVault {
+    #[cfg(feature = "compression")]
+    compression: Option<Compression>,
+    #[cfg(feature = "encryption")]
+    pub key: Option<KeyId>,
+    #[cfg(feature = "encryption")]
+    pub vault: Arc<Vault>,
+}
+
+#[cfg(all(feature = "compression", feature = "encryption"))]
+impl TreeVault {
+    pub(crate) fn new_if_needed(
+        key: Option<KeyId>,
+        vault: &Arc<Vault>,
+        compression: Option<Compression>,
+    ) -> Option<Self> {
+        if key.is_none() && compression.is_none() {
+            None
+        } else {
+            Some(Self {
+                key,
+                compression,
+                vault: vault.clone(),
+            })
+        }
+    }
+
+    fn header(&self, compressed: bool) -> u8 {
+        let mut bits = if self.key.is_some() { 0b1000_0000 } else { 0 };
+
+        if compressed {
+            if let Some(compression) = self.compression {
+                bits |= compression as u8;
+            }
+        }
+
+        bits
+    }
+}
+
+#[cfg(all(feature = "compression", feature = "encryption"))]
+impl nebari::Vault for TreeVault {
+    type Error = Error;
+
+    fn encrypt(&self, payload: &[u8]) -> Result<Vec<u8>, Error> {
+        use std::borrow::Cow;
+
+        // TODO this allocates too much. The vault should be able to do an
+        // in-place encryption operation so that we can use a single buffer.
+        let mut includes_compression = false;
+        let compressed = match (payload.len(), self.compression) {
+            (128..=usize::MAX, Some(Compression::Lz4)) => {
+                includes_compression = true;
+                Cow::Owned(lz4_flex::block::compress_prepend_size(payload))
+            }
+            _ => Cow::Borrowed(payload),
+        };
+
+        let mut complete = if let Some(key) = &self.key {
+            self.vault.encrypt_payload(key, &compressed, None)?
+        } else {
+            compressed.into_owned()
+        };
+
+        let header = self.header(includes_compression);
+        if header != 0 {
+            let header = [b't', b'r', b'v', header];
+            complete.splice(0..0, header);
+        }
+
+        Ok(complete)
+    }
+
+    fn decrypt(&self, payload: &[u8]) -> Result<Vec<u8>, Error> {
+        use std::borrow::Cow;
+
+        if payload.len() >= 4 && &payload[0..3] == b"trv" {
+            let header = payload[3];
+            let payload = &payload[4..];
+            let encrypted = (header & 0b1000_0000) != 0;
+            let compression = header & 0b0111_1111;
+            let decrypted = if encrypted {
+                Cow::Owned(self.vault.decrypt_payload(payload, None)?)
+            } else {
+                Cow::Borrowed(payload)
+            };
+            #[allow(clippy::single_match)] // Make it an error when we add a new algorithm
+            return Ok(match Compression::from_u8(compression) {
+                Some(Compression::Lz4) => {
+                    lz4_flex::block::decompress_size_prepended(&decrypted).map_err(Error::from)?
+                }
+                None => decrypted.into_owned(),
+            });
+        }
+        self.vault.decrypt_payload(payload, None)
+    }
+}
+
+#[cfg(all(feature = "compression", not(feature = "encryption")))]
+impl TreeVault {
+    pub(crate) fn new_if_needed(compression: Option<Compression>) -> Option<Self> {
+        compression.map(|compression| Self {
+            compression: Some(compression),
+        })
+    }
+}
+
+#[cfg(all(feature = "compression", not(feature = "encryption")))]
+impl nebari::Vault for TreeVault {
+    type Error = Error;
+
+    fn encrypt(&self, payload: &[u8]) -> Result<Vec<u8>, Error> {
+        Ok(match self.compression {
+            Some(Compression::Lz4) => {
+                let mut destination =
+                    vec![0; lz4_flex::block::get_maximum_output_size(payload.len()) + 8];
+                let compressed_length =
+                    lz4_flex::block::compress_into(payload, &mut destination[8..])
+                        .expect("lz4-flex documents this shouldn't fail");
+                destination.truncate(compressed_length + 8);
+                destination[0..4].copy_from_slice(&[b't', b'r', b'v', Compression::Lz4 as u8]);
+                // to_le_bytes() makes it compatible with lz4-flex decompress_size_prepended.
+                let uncompressed_length =
+                    u32::try_from(payload.len()).expect("nebari doesn't support >32 bit blocks");
+                destination[4..8].copy_from_slice(&uncompressed_length.to_le_bytes());
+                destination
+            }
+            // TODO this shouldn't copy
+            None => payload.to_vec(),
+        })
+    }
+
+    fn decrypt(&self, payload: &[u8]) -> Result<Vec<u8>, Error> {
+        if payload.len() >= 4 && &payload[0..3] == b"trv" {
+            let header = payload[3];
+            let payload = &payload[4..];
+            let encrypted = (header & 0b1000_0000) != 0;
+            let compression = header & 0b0111_1111;
+            if encrypted {
+                return Err(Error::EncryptionDisabled);
+            }
+
+            #[allow(clippy::single_match)] // Make it an error when we add a new algorithm
+            return Ok(match Compression::from_u8(compression) {
+                Some(Compression::Lz4) => {
+                    lz4_flex::block::decompress_size_prepended(payload).map_err(Error::from)?
+                }
+                None => payload.to_vec(),
+            });
+        }
+        Ok(payload.to_vec())
+    }
+}
+
+#[cfg(all(not(feature = "compression"), feature = "encryption"))]
+impl TreeVault {
+    pub(crate) fn new_if_needed(key: Option<KeyId>, vault: &Arc<Vault>) -> Option<Self> {
+        key.map(|key| Self {
+            key: Some(key),
+            vault: vault.clone(),
+        })
+    }
+
+    #[allow(dead_code)] // This implementation is sort of documentation for what it would be. But our Vault payload already can detect if a parsing error occurs, so we don't need a header if only encryption is enabled.
+    fn header(&self) -> u8 {
+        if self.key.is_some() {
+            0b1000_0000
+        } else {
+            0
+        }
+    }
+}
+
+#[cfg(all(not(feature = "compression"), feature = "encryption"))]
+impl nebari::Vault for TreeVault {
+    type Error = Error;
+
+    fn encrypt(&self, payload: &[u8]) -> Result<Vec<u8>, Error> {
+        if let Some(key) = &self.key {
+            self.vault.encrypt_payload(key, payload, None)
+        } else {
+            // TODO does this need to copy?
+            Ok(payload.to_vec())
+        }
+    }
+
+    fn decrypt(&self, payload: &[u8]) -> Result<Vec<u8>, Error> {
+        self.vault.decrypt_payload(payload, None)
     }
 }

--- a/crates/bonsaidb-local/src/tests.rs
+++ b/crates/bonsaidb-local/src/tests.rs
@@ -32,6 +32,12 @@ macro_rules! define_local_suite {
                     if stringify!($name) == "memory" {
                         config = config.memory_only()
                     }
+
+                    #[cfg(feature = "compression")]
+                    {
+                        config = config.default_compression(crate::config::Compression::Lz4);
+                    }
+
                     let storage = Storage::open(config).await?;
                     storage
                         .create_database::<BasicSchema>("tests", false)

--- a/crates/bonsaidb-local/src/vault.rs
+++ b/crates/bonsaidb-local/src/vault.rs
@@ -53,7 +53,6 @@ use std::{
     collections::HashMap,
     fmt::{Debug, Display},
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -737,23 +736,5 @@ mod tests {
                 _
             )))
         ));
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct TreeVault {
-    pub key: KeyId,
-    pub vault: Arc<Vault>,
-}
-
-impl nebari::Vault for TreeVault {
-    type Error = crate::Error;
-
-    fn encrypt(&self, payload: &[u8]) -> Result<Vec<u8>, crate::Error> {
-        self.vault.encrypt_payload(&self.key, payload, None)
-    }
-
-    fn decrypt(&self, payload: &[u8]) -> Result<Vec<u8>, crate::Error> {
-        self.vault.decrypt_payload(payload, None)
     }
 }

--- a/crates/bonsaidb-server/Cargo.toml
+++ b/crates/bonsaidb-server/Cargo.toml
@@ -13,7 +13,14 @@ homepage = "https://bonsaidb.io/"
 
 [features]
 default = ["full"]
-full = ["cli", "websockets", "acme", "encryption", "password-hashing"]
+full = [
+    "cli",
+    "websockets",
+    "acme",
+    "encryption",
+    "password-hashing",
+    "compression",
+]
 cli = ["clap", "pem", "env_logger", "bonsaidb-local/cli"]
 test-util = ["bonsaidb-core/test-util"]
 websockets = [
@@ -30,6 +37,7 @@ password-hashing = [
     "bonsaidb-local/password-hashing",
     "bonsaidb-core/password-hashing",
 ]
+compression = ["bonsaidb-local/compression"]
 
 included-from-omnibus = []
 

--- a/crates/bonsaidb-server/src/config.rs
+++ b/crates/bonsaidb-server/src/config.rs
@@ -10,7 +10,7 @@ use bonsaidb_local::config::{Builder, KeyValuePersistence, StorageConfiguration}
 use bonsaidb_local::vault::AnyVaultKeyStorage;
 
 /// Configuration options for [`Server`](crate::Server)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use]
 #[non_exhaustive]
 pub struct ServerConfiguration {
@@ -106,7 +106,7 @@ impl Default for ServerConfiguration {
 #[cfg(feature = "acme")]
 mod acme {
     /// The Automated Certificate Management Environment (ACME) configuration.
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub struct AcmeConfiguration {
         /// The contact email to register with the ACME directory for the account.
         pub contact_email: Option<String>,
@@ -131,7 +131,7 @@ mod acme {
 pub use acme::*;
 
 /// The default permissions to use for all connections to the server.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum DefaultPermissions {
     /// Allow all permissions. Do not use outside of completely trusted environments.
     AllowAll,

--- a/crates/bonsaidb-server/src/config.rs
+++ b/crates/bonsaidb-server/src/config.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 #[cfg(feature = "encryption")]
 use bonsaidb_core::document::KeyId;
 use bonsaidb_core::{permissions::Permissions, schema::Schema};
+#[cfg(feature = "compression")]
+use bonsaidb_local::config::Compression;
 use bonsaidb_local::config::{Builder, KeyValuePersistence, StorageConfiguration};
 #[cfg(feature = "encryption")]
 use bonsaidb_local::vault::AnyVaultKeyStorage;
@@ -185,6 +187,12 @@ impl Builder for ServerConfiguration {
     #[cfg(feature = "encryption")]
     fn default_encryption_key(mut self, key: KeyId) -> Self {
         self.storage.default_encryption_key = Some(key);
+        self
+    }
+
+    #[cfg(feature = "compression")]
+    fn default_compression(mut self, compression: Compression) -> Self {
+        self.storage.default_compression = Some(compression);
         self
     }
 

--- a/crates/bonsaidb-server/src/config.rs
+++ b/crates/bonsaidb-server/src/config.rs
@@ -180,7 +180,7 @@ impl Builder for ServerConfiguration {
         mut self,
         key_storage: VaultKeyStorage,
     ) -> Self {
-        self.storage.vault_key_storage = Some(Box::new(key_storage));
+        self.storage.vault_key_storage = Some(std::sync::Arc::new(key_storage));
         self
     }
 

--- a/crates/bonsaidb-server/src/test_util.rs
+++ b/crates/bonsaidb-server/src/test_util.rs
@@ -9,14 +9,17 @@ use crate::{config::DefaultPermissions, Error, Server, ServerConfiguration};
 
 pub const BASIC_SERVER_NAME: &str = "basic-server";
 
+#[cfg_attr(not(feature = "compression"), allow(unused_mut))]
 pub async fn initialize_basic_server(path: &Path) -> Result<Server, Error> {
-    let server = Server::open(
-        ServerConfiguration::new(path)
-            .server_name(BASIC_SERVER_NAME)
-            .default_permissions(DefaultPermissions::AllowAll)
-            .with_schema::<BasicSchema>()?,
-    )
-    .await?;
+    let mut config = ServerConfiguration::new(path)
+        .server_name(BASIC_SERVER_NAME)
+        .default_permissions(DefaultPermissions::AllowAll)
+        .with_schema::<BasicSchema>()?;
+    #[cfg(feature = "compression")]
+    {
+        config = config.default_compression(bonsaidb_local::config::Compression::Lz4);
+    }
+    let server = Server::open(config).await?;
     assert_eq!(server.primary_domain(), BASIC_SERVER_NAME);
 
     server.install_self_signed_certificate(false).await?;

--- a/crates/bonsaidb/Cargo.toml
+++ b/crates/bonsaidb/Cargo.toml
@@ -44,6 +44,7 @@ local-full = [
     "local-encryption",
     "local-multiuser",
     "local-password-hashing",
+    "local-compression",
 ]
 local = ["bonsaidb-local"]
 server-full = [
@@ -56,6 +57,7 @@ server-full = [
     "server-hyper",
     "server-pem",
     "server-password-hashing",
+    "server-compression",
 ]
 server = ["bonsaidb-server", "local"]
 client-full = [
@@ -101,6 +103,9 @@ client-password-hashing = [
     "password-hashing",
     "bonsaidb-client/password-hashing",
 ]
+
+local-compression = ["bonsaidb-local/compression"]
+server-compression = ["bonsaidb-server/compression"]
 
 [dependencies]
 bonsaidb-core = { path = "../bonsaidb-core", version = "0.1.1", default-features = false, features = [

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -106,6 +106,12 @@ fn all_tests() -> &'static [TestSuite] {
             cargo_args: "--package bonsaidb-local --no-default-features --features encryption",
         },
         TestSuite {
+            cargo_args: "--package bonsaidb-local --no-default-features --features compression",
+        },
+        TestSuite {
+            cargo_args: "--package bonsaidb-local --no-default-features --features encryption,compression",
+        },
+        TestSuite {
             cargo_args: "--package bonsaidb-local --no-default-features --features multiuser",
         },
         TestSuite {
@@ -121,6 +127,12 @@ fn all_tests() -> &'static [TestSuite] {
             cargo_args: "--package bonsaidb-server --no-default-features --features encryption",
         },
         TestSuite {
+            cargo_args: "--package bonsaidb-server --no-default-features --features encryption,compression",
+        },
+        TestSuite {
+            cargo_args: "--package bonsaidb-server --no-default-features --features compression",
+        },
+        TestSuite {
             cargo_args: "--package bonsaidb-server --no-default-features --features websockets",
         },
         TestSuite {
@@ -130,10 +142,16 @@ fn all_tests() -> &'static [TestSuite] {
             cargo_args: "--package bonsaidb --no-default-features --features server,client,test-util",
         },
         TestSuite {
-            cargo_args: "--package bonsaidb --no-default-features --features server,client,test-util,websockets",
+            cargo_args: "--package bonsaidb --no-default-features --features server,client,test-util,server-password-hashing,client-password-hashing,websockets",
         },
         TestSuite {
-            cargo_args: "--package bonsaidb --no-default-features --features server,client,test-util,server-acme",
+            cargo_args: "--package bonsaidb --no-default-features --features server,client,test-util,server-password-hashing,client-password-hashing,server-acme",
+        },
+        TestSuite {
+            cargo_args: "--package bonsaidb --no-default-features --features server,client,test-util,server-password-hashing,client-password-hashing,server-compression",
+        },
+        TestSuite {
+            cargo_args: "--package bonsaidb --no-default-features --features server,client,test-util,server-password-hashing,client-password-hashing,server-encryption",
         },
         TestSuite {
             cargo_args:


### PR DESCRIPTION
Closes #185

This is a first pass at compression support. I believe that ultimately
we'll want to support both zstd and lz4, but right now feature flags are
really annoying to implement. When we can implement namespaced features
(#178), we should revisit adding multiple compression backends and
options. lz4-flex has a faster unsafe option that can be enabled
optionally, but I've kept disabled in the spirit of BonsaiDb's "safe"
defaults.

From my research, zstd will be preferred when storage is at a premium,
but lz4 *should* be faster in general. I want to write a good benchmark
suite, because I believe the relative performance will potentially be
hardware dependent, and users should be able to gauge what works best
for them.