### PR TITLE
Work around panic in tokio::time::sleep()

### DIFF
--- a/crates/bonsaidb-local/src/database.rs
+++ b/crates/bonsaidb-local/src/database.rs
@@ -45,6 +45,7 @@ use tokio::sync::watch;
 use crate::vault::TreeVault;
 use crate::{
     config::{Builder, KeyValuePersistence, StorageConfiguration},
+    database::keyvalue::BackgroundWorkerProcessTarget,
     error::Error,
     open_trees::OpenTrees,
     views::{
@@ -1436,7 +1437,8 @@ impl Borrow<Roots<AnyFile>> for Context {
 
 impl Context {
     pub(crate) fn new(roots: Roots<AnyFile>, key_value_persistence: KeyValuePersistence) -> Self {
-        let (background_sender, background_receiver) = watch::channel(None);
+        let (background_sender, background_receiver) =
+            watch::channel(BackgroundWorkerProcessTarget::Never);
         let key_value_state = Arc::new(Mutex::new(keyvalue::KeyValueState::new(
             key_value_persistence,
             roots.clone(),


### PR DESCRIPTION
A user showed a stack trace of a crash that resulted from the key-value
background task attempting to sleep forever by passing a large Duration.
The example the user was running doesn't use expiration at all, so the
loop is meant to sleep forever.

I'm uncertain what is causing this to panic on their machine and not on
any of the test environments I've run on except that they're on Windows.
The tokio code as far as I can tell has no platform-specific code in
that area, so I'm baffled. I reported tokio-rs/tokio#4494.

In the meantime, I've changed the logic to support a "Never" sleep
target which avoids calling sleep() when there's no expiration target.
This makes the code a little more complicated (the reason I went with
the original approach), but it should fix the panic the user was seeing.