### PR TITLE
Test Large Datasets/Create Open-Library Data Importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   This is supported by a new trait, `IntoPrefixRange`. This trait has been
   implemented for all byte-based key implementations as well as for `String`.
+- `Operation::push_serialized` has been added, which calls `natural_id` before
+  creating an `Operation::Insert` variant.
+- `Tasks::parallelization` and `Builder::workers_parallelization` have been
+  added as a way to control how many threads can be used by any given
+  task/worker. This is automatically configured to be the number of cpu cores
+  detected.
 
 ## v0.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 # actionable = { git = "https://github.com/khonsulabs/actionable.git", branch = "lifetimes" }
 # actionable = { path = "../actionable/actionable", version = "0.2" }
 # nebari = { path = "../nebari/nebari", version = "0.3" }
-nebari = { git = "https://github.com/khonsulabs/nebari.git", branch = "main" }
+# nebari = { git = "https://github.com/khonsulabs/nebari.git", branch = "main" }
 # arc-bytes = { path = "../shared-buffer" }
 
 # [patch."https://github.com/khonsulabs/custodian.git"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 # actionable = { git = "https://github.com/khonsulabs/actionable.git", branch = "lifetimes" }
 # actionable = { path = "../actionable/actionable", version = "0.2" }
 # nebari = { path = "../nebari/nebari", version = "0.3" }
-# nebari = { git = "https://github.com/khonsulabs/nebari.git", branch = "main" }
+nebari = { git = "https://github.com/khonsulabs/nebari.git", branch = "main" }
 # arc-bytes = { path = "../shared-buffer" }
 
 # [patch."https://github.com/khonsulabs/custodian.git"]

--- a/crates/bonsaidb-core/src/document/revision.rs
+++ b/crates/bonsaidb-core/src/document/revision.rs
@@ -1,10 +1,10 @@
-use std::fmt::{Display, Write};
+use std::fmt::{Debug, Display, Write};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 /// Information about a `Document`'s revision history.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Revision {
     /// The current revision id of the document. This value is sequentially incremented on each document update.
     pub id: u32,
@@ -51,9 +51,15 @@ impl Revision {
     }
 }
 
+impl Debug for Revision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Revision({})", self)
+    }
+}
+
 impl Display for Revision {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.id.fmt(f)?;
+        <u32 as Display>::fmt(&self.id, f)?;
         f.write_char('-')?;
         for byte in self.sha256 {
             f.write_fmt(format_args!("{:02x}", byte))?;
@@ -114,5 +120,9 @@ fn revision_display_test() {
     assert_eq!(
         first_revision.to_string(),
         "0-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add73ff431ed"
+    );
+    assert_eq!(
+        format!("{:?}", first_revision),
+        "Revision(0-7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add73ff431ed)"
     );
 }

--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -52,7 +52,7 @@ bonsaidb-core = { path = "../bonsaidb-core", version = "=0.2.0", features = [
     "included-from-local",
 ] }
 bonsaidb-utils = { path = "../bonsaidb-utils", version = "=0.2.0" }
-nebari = { version = "0.3.1" }
+nebari = { version = "0.4.0" }
 thiserror = "1"
 tokio = { version = "1.16.1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -84,6 +84,7 @@ argon2 = { version = "^0.3.3", optional = true, features = ["parallel"] }
 sysinfo = { version = "0.23", default-features = false }
 once_cell = { version = "1", optional = true }
 lz4_flex = { version = "0.9.2", optional = true }
+easy-parallel = "3.2.0"
 
 [dev-dependencies]
 bonsaidb-core = { path = "../bonsaidb-core", version = "=0.2.0", features = [

--- a/crates/bonsaidb-local/src/config.rs
+++ b/crates/bonsaidb-local/src/config.rs
@@ -117,19 +117,26 @@ impl StorageConfiguration {
 #[derive(Debug, Clone)]
 pub struct Tasks {
     /// Defines how many workers should be spawned to process tasks. This
-    /// defaults to the 2x the number of cpu cores available to the system or 4, whichever is larger.
+    /// defaults to the 2x the number of cpu cores available to the system or 2,
+    /// whichever is larger.
     pub worker_count: usize,
+
+    /// Defines how many simultaneous threads should be used when a task is
+    /// parallelizable. This defaults to the nuber of cpu cores available to the
+    /// system.
+    pub parallelization: usize,
 }
 
 impl SystemDefault for Tasks {
     fn default_for(system: &System) -> Self {
+        let num_cpus = system
+            .physical_core_count()
+            .unwrap_or(0)
+            .max(system.processors().len())
+            .max(1);
         Self {
-            worker_count: system
-                .physical_core_count()
-                .unwrap_or(0)
-                .max(system.processors().len())
-                .max(1)
-                * 2,
+            worker_count: num_cpus * 2,
+            parallelization: num_cpus,
         }
     }
 }
@@ -307,13 +314,12 @@ pub trait Builder: Default {
         Self::default().path(path)
     }
 
-    /// Sets [`StorageConfiguration::path`](StorageConfiguration#structfield.memory_only) to true and returns self.
-    #[must_use]
-    fn memory_only(self) -> Self;
-
     /// Registers the schema and returns self.
     fn with_schema<S: Schema>(self) -> Result<Self, Error>;
 
+    /// Sets [`StorageConfiguration::path`](StorageConfiguration#structfield.memory_only) to true and returns self.
+    #[must_use]
+    fn memory_only(self) -> Self;
     /// Sets [`StorageConfiguration::path`](StorageConfiguration#structfield.path) to `path` and returns self.
     #[must_use]
     fn path<P: AsRef<Path>>(self, path: P) -> Self;
@@ -334,6 +340,9 @@ pub trait Builder: Default {
     /// Sets [`Tasks::worker_count`] to `worker_count` and returns self.
     #[must_use]
     fn tasks_worker_count(self, worker_count: usize) -> Self;
+    /// Sets [`Tasks::parallelization`] to `parallelization` and returns self.
+    #[must_use]
+    fn tasks_parallelization(self, parallelization: usize) -> Self;
     /// Sets [`Views::check_integrity_on_open`] to `check` and returns self.
     #[must_use]
     fn check_view_integrity_on_open(self, check: bool) -> Self;
@@ -341,7 +350,6 @@ pub trait Builder: Default {
     #[cfg(feature = "compression")]
     #[must_use]
     fn default_compression(self, compression: Compression) -> Self;
-
     /// Sets [`StorageConfiguration::key_value_persistence`](StorageConfiguration#structfield.key_value_persistence) to `persistence` and returns self.
     #[must_use]
     fn key_value_persistence(self, persistence: KeyValuePersistence) -> Self;
@@ -391,6 +399,11 @@ impl Builder for StorageConfiguration {
 
     fn tasks_worker_count(mut self, worker_count: usize) -> Self {
         self.workers.worker_count = worker_count;
+        self
+    }
+
+    fn tasks_parallelization(mut self, parallelization: usize) -> Self {
+        self.workers.parallelization = parallelization;
         self
     }
 

--- a/crates/bonsaidb-local/src/open_trees.rs
+++ b/crates/bonsaidb-local/src/open_trees.rs
@@ -10,10 +10,7 @@ use nebari::{
 use crate::storage::TreeVault;
 use crate::{
     database::document_tree_name,
-    views::{
-        view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name,
-        view_omitted_docs_tree_name,
-    },
+    views::{view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name},
 };
 
 #[derive(Default)]
@@ -61,11 +58,6 @@ impl OpenTrees {
             for view in views {
                 let view_name = view.view_name();
                 if view.unique() {
-                    self.open_tree::<Unversioned>(
-                        &view_omitted_docs_tree_name(&view_name),
-                        #[cfg(any(feature = "encryption", feature = "compression"))]
-                        vault.clone(),
-                    );
                     self.open_tree::<Unversioned>(
                         &view_document_map_tree_name(&view_name),
                         #[cfg(any(feature = "encryption", feature = "compression"))]

--- a/crates/bonsaidb-local/src/storage.rs
+++ b/crates/bonsaidb-local/src/storage.rs
@@ -1027,7 +1027,7 @@ impl nebari::Vault for TreeVault {
                 destination
             }
             // TODO this shouldn't copy
-            (_, None) => payload.to_vec(),
+            _ => payload.to_vec(),
         })
     }
 

--- a/crates/bonsaidb-local/src/storage.rs
+++ b/crates/bonsaidb-local/src/storage.rs
@@ -249,7 +249,7 @@ impl Storage {
                     tree_vault,
                     path: owned_path,
                     file_manager,
-                    chunk_cache: ChunkCache::new(10000, 160_384),
+                    chunk_cache: ChunkCache::new(2000, 160_384),
                     threadpool: ThreadPool::new(parallelization),
                     schemas: RwLock::new(configuration.initial_schemas),
                     available_databases: RwLock::default(),

--- a/crates/bonsaidb-local/src/storage.rs
+++ b/crates/bonsaidb-local/src/storage.rs
@@ -1011,8 +1011,8 @@ impl nebari::Vault for TreeVault {
     type Error = Error;
 
     fn encrypt(&self, payload: &[u8]) -> Result<Vec<u8>, Error> {
-        Ok(match self.compression {
-            Some(Compression::Lz4) => {
+        Ok(match (payload.len(), self.compression) {
+            (128..=usize::MAX, Some(Compression::Lz4)) => {
                 let mut destination =
                     vec![0; lz4_flex::block::get_maximum_output_size(payload.len()) + 8];
                 let compressed_length =
@@ -1027,7 +1027,7 @@ impl nebari::Vault for TreeVault {
                 destination
             }
             // TODO this shouldn't copy
-            None => payload.to_vec(),
+            (_, None) => payload.to_vec(),
         })
     }
 

--- a/crates/bonsaidb-local/src/storage.rs
+++ b/crates/bonsaidb-local/src/storage.rs
@@ -246,7 +246,7 @@ impl Storage {
                     tree_vault,
                     path: owned_path,
                     file_manager,
-                    chunk_cache: ChunkCache::new(2000, 160_384),
+                    chunk_cache: ChunkCache::new(10000, 160_384),
                     threadpool: ThreadPool::default(),
                     schemas: RwLock::new(configuration.initial_schemas),
                     available_databases: RwLock::default(),

--- a/crates/bonsaidb-local/src/tasks/compactor.rs
+++ b/crates/bonsaidb-local/src/tasks/compactor.rs
@@ -10,7 +10,7 @@ use crate::{
     tasks::{Job, Keyed, Task},
     views::{
         view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name,
-        view_omitted_docs_tree_name, view_versions_tree_name,
+        view_versions_tree_name,
     },
     Database, Error,
 };
@@ -159,7 +159,6 @@ fn compact_view(database: &Database, name: &ViewName) -> Result<(), Error> {
     compact_tree::<Unversioned, _>(database, view_entries_tree_name(name))?;
     compact_tree::<Unversioned, _>(database, view_document_map_tree_name(name))?;
     compact_tree::<Unversioned, _>(database, view_invalidated_docs_tree_name(name))?;
-    compact_tree::<Unversioned, _>(database, view_omitted_docs_tree_name(name))?;
 
     Ok(())
 }

--- a/crates/bonsaidb-local/src/tasks/compactor.rs
+++ b/crates/bonsaidb-local/src/tasks/compactor.rs
@@ -69,8 +69,7 @@ impl Target {
         match self {
             Target::Collection(collection) => {
                 let database = database.clone();
-                tokio::task::spawn_blocking(move || compact_collection(&database, &collection))
-                    .await?
+                compact_collection(database.clone(), &collection).await
             }
             Target::KeyValue => {
                 let database = database.clone();
@@ -123,17 +122,36 @@ impl Keyed<Task> for Compactor {
         Task::Compaction(self.compaction.clone())
     }
 }
-fn compact_collection(database: &Database, collection: &CollectionName) -> Result<(), Error> {
+async fn compact_collection(database: Database, collection: &CollectionName) -> Result<(), Error> {
     // Compact the main database file
-    compact_tree::<Versioned, _>(database, document_tree_name(collection))?;
+    let mut handles = FuturesUnordered::new();
+    let task_db = database.clone();
+    let document_tree_name = document_tree_name(collection);
+    handles.push(tokio::task::spawn_blocking(move || {
+        compact_tree::<Versioned, _>(&task_db, document_tree_name)
+    }));
 
     // Compact the views
     if let Some(views) = database.data.schema.views_in_collection(collection) {
         for view in views {
-            compact_view(database, &view.view_name())?;
+            let task_db = database.clone();
+            let view_name = view.view_name();
+            handles.push(tokio::task::spawn_blocking(move || {
+                compact_view(&task_db, &view_name)
+            }));
         }
     }
-    compact_tree::<Unversioned, _>(database, view_versions_tree_name(collection))?;
+
+    let task_db = database.clone();
+    let view_versions_tree_name = view_versions_tree_name(collection);
+    handles.push(tokio::task::spawn_blocking(move || {
+        compact_tree::<Unversioned, _>(&task_db, view_versions_tree_name)
+    }));
+
+    while let Some(result) = handles.next().await {
+        result??;
+    }
+
     Ok(())
 }
 

--- a/crates/bonsaidb-local/src/views.rs
+++ b/crates/bonsaidb-local/src/views.rs
@@ -34,10 +34,6 @@ pub fn view_invalidated_docs_tree_name(view_name: &impl Display) -> String {
     format!("view.{:#}.invalidated", view_name)
 }
 
-pub fn view_omitted_docs_tree_name(view_name: &impl Display) -> String {
-    format!("view.{:#}.omitted", view_name)
-}
-
 pub fn view_versions_tree_name(collection: &CollectionName) -> String {
     format!("view-versions.{:#}", collection)
 }

--- a/crates/bonsaidb-local/src/views/mapper.rs
+++ b/crates/bonsaidb-local/src/views/mapper.rs
@@ -151,7 +151,6 @@ fn map_view(
                 .view_by_name(&map_request.view_name)
                 .unwrap();
 
-            // todo reuse these vecs
             let document_ids = invalidated_ids
                 .drain(invalidated_ids.len().saturating_sub(CHUNK_SIZE)..)
                 .collect::<Vec<_>>();
@@ -183,7 +182,6 @@ pub struct DocumentRequest<'a> {
     pub map_request: &'a Map,
     pub database: &'a Database,
 
-    // pub transaction: &'a mut ExecutingTransaction<AnyFile>,
     pub document_map: &'a UnlockedTransactionTree<AnyFile>,
     pub documents: &'a UnlockedTransactionTree<AnyFile>,
     pub view_entries: &'a UnlockedTransactionTree<AnyFile>,

--- a/crates/bonsaidb-local/src/views/mapper.rs
+++ b/crates/bonsaidb-local/src/views/mapper.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::{hash_map::RandomState, BTreeMap, BTreeSet, HashSet, VecDeque},
+    collections::{hash_map::RandomState, BTreeMap, BTreeSet, HashSet},
     sync::Arc,
 };
 
@@ -17,7 +17,7 @@ use easy_parallel::Parallel;
 use nebari::{
     io::any::AnyFile,
     tree::{AnyTreeRoot, CompareSwap, KeyOperation, Operation, Unversioned, Versioned},
-    ExecutingTransaction, Tree,
+    LockedTransactionTree, Tree, UnlockedTransactionTree,
 };
 
 use crate::{
@@ -25,7 +25,7 @@ use crate::{
     tasks::{Job, Keyed, Task},
     views::{
         view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name,
-        view_omitted_docs_tree_name, EntryMapping, ViewEntry,
+        EntryMapping, ViewEntry,
     },
     Error,
 };
@@ -83,13 +83,6 @@ impl Job for Mapper {
                     view_invalidated_docs_tree_name(&self.map.view_name),
                 )?)?;
 
-        let omitted_entries =
-            self.database
-                .roots()
-                .tree(self.database.collection_tree::<Unversioned, _>(
-                    &self.map.collection,
-                    view_omitted_docs_tree_name(&self.map.view_name),
-                )?)?;
         let transaction_id = self
             .database
             .last_transaction_id()
@@ -104,7 +97,6 @@ impl Job for Mapper {
                 &invalidated_entries,
                 &document_map,
                 &documents,
-                &omitted_entries,
                 &view_entries,
                 &storage,
                 &map_request,
@@ -132,7 +124,6 @@ fn map_view(
     invalidated_entries: &Tree<Unversioned, AnyFile>,
     document_map: &Tree<Unversioned, AnyFile>,
     documents: &Tree<Versioned, AnyFile>,
-    omitted_entries: &Tree<Unversioned, AnyFile>,
     view_entries: &Tree<Unversioned, AnyFile>,
     database: &Database,
     map_request: &Map,
@@ -145,41 +136,42 @@ fn map_view(
         .map(|(key, _)| key)
         .collect::<Vec<_>>();
     while !invalidated_ids.is_empty() {
-        let mut transaction = database
+        let transaction = database
             .roots()
             .transaction::<_, dyn AnyTreeRoot<AnyFile>>(&[
                 Box::new(invalidated_entries.clone()) as Box<dyn AnyTreeRoot<AnyFile>>,
                 Box::new(document_map.clone()),
                 Box::new(documents.clone()),
-                Box::new(omitted_entries.clone()),
                 Box::new(view_entries.clone()),
             ])?;
-        let view = database
-            .data
-            .schema
-            .view_by_name(&map_request.view_name)
-            .unwrap();
+        {
+            let view = database
+                .data
+                .schema
+                .view_by_name(&map_request.view_name)
+                .unwrap();
 
-        // todo reuse these vecs
-        let document_ids = invalidated_ids
-            .drain(invalidated_ids.len().saturating_sub(CHUNK_SIZE)..)
-            .collect::<Vec<_>>();
+            // todo reuse these vecs
+            let document_ids = invalidated_ids
+                .drain(invalidated_ids.len().saturating_sub(CHUNK_SIZE)..)
+                .collect::<Vec<_>>();
+            let document_map = transaction.unlocked_tree(1).unwrap();
+            let documents = transaction.unlocked_tree(2).unwrap();
+            let view_entries = transaction.unlocked_tree(3).unwrap();
+            DocumentRequest {
+                document_ids: document_ids.clone(),
+                map_request,
+                database,
+                document_map,
+                documents,
+                view_entries,
+                view,
+            }
+            .map()?;
 
-        DocumentRequest {
-            document_ids: document_ids.clone(),
-            map_request,
-            database,
-            transaction: &mut transaction,
-            document_map_index: 1,
-            documents_index: 2,
-            omitted_entries_index: 3,
-            view_entries_index: 4,
-            view,
+            let mut invalidated_entries = transaction.tree::<Unversioned>(0).unwrap();
+            invalidated_entries.modify(document_ids, nebari::tree::Operation::Remove)?;
         }
-        .map()?;
-
-        let invalidated_entries = transaction.tree::<Unversioned>(0).unwrap();
-        invalidated_entries.modify(document_ids, nebari::tree::Operation::Remove)?;
         transaction.commit()?;
     }
 
@@ -191,64 +183,72 @@ pub struct DocumentRequest<'a> {
     pub map_request: &'a Map,
     pub database: &'a Database,
 
-    pub transaction: &'a mut ExecutingTransaction<AnyFile>,
-    pub document_map_index: usize,
-    pub documents_index: usize,
-    pub omitted_entries_index: usize,
-    pub view_entries_index: usize,
+    // pub transaction: &'a mut ExecutingTransaction<AnyFile>,
+    pub document_map: &'a UnlockedTransactionTree<AnyFile>,
+    pub documents: &'a UnlockedTransactionTree<AnyFile>,
+    pub view_entries: &'a UnlockedTransactionTree<AnyFile>,
     pub view: &'a dyn Serialized,
 }
 
+type DocumentIdPayload = (ArcBytes<'static>, Option<ArcBytes<'static>>);
+type BatchPayload = (Vec<ArcBytes<'static>>, flume::Receiver<DocumentIdPayload>);
+
 impl<'a> DocumentRequest<'a> {
-    #[allow(clippy::too_many_lines)]
-    pub fn map(&mut self) -> Result<(), Error> {
-        for chunk in self.document_ids.chunks(1024) {
+    fn generate_batches(
+        batch_sender: flume::Sender<BatchPayload>,
+        document_ids: &[ArcBytes<'static>],
+        documents: &UnlockedTransactionTree<AnyFile>,
+    ) -> Result<(), Error> {
+        // Generate batches
+        let mut documents = documents.lock::<Versioned>();
+        for chunk in document_ids.chunks(1024) {
             let (document_id_sender, document_id_receiver) = flume::bounded(chunk.len());
-            let mut document_maps = BTreeMap::new();
-            let mut document_keys = BTreeMap::new();
-            let mut document_statuses = BTreeMap::new();
-            let mut new_mappings = BTreeMap::new();
-            let mut all_keys = BTreeSet::new();
+            batch_sender
+                .send((chunk.to_vec(), document_id_receiver))
+                .unwrap();
+            let mut documents = documents.get_multiple(chunk.iter().map(ArcBytes::as_slice))?;
+            documents.sort_by(|a, b| a.0.cmp(&b.0));
+
+            for document_id in chunk.iter().rev() {
+                let document = documents
+                    .last()
+                    .map_or(false, |(key, _)| (key == document_id))
+                    .then(|| documents.pop().unwrap().1);
+
+                document_id_sender
+                    .send((document_id.clone(), document))
+                    .unwrap();
+            }
+
+            drop(document_id_sender);
+        }
+        drop(batch_sender);
+        Ok(())
+    }
+
+    fn map_batches(
+        batch_receiver: &flume::Receiver<BatchPayload>,
+        mapped_sender: flume::Sender<Batch>,
+        view: &dyn Serialized,
+    ) -> Result<(), Error> {
+        // Process batches
+        while let Ok((document_ids, document_id_receiver)) = batch_receiver.recv() {
+            let mut batch = Batch {
+                document_ids,
+                ..Batch::default()
+            };
             for result in Parallel::new()
-                .add(|| {
-                    let documents = self
-                        .transaction
-                        .tree::<Versioned>(self.documents_index)
-                        .unwrap();
-                    let mut documents =
-                        documents.get_multiple(chunk.iter().map(ArcBytes::as_slice))?;
-                    documents.sort_by(|a, b| a.0.cmp(&b.0));
-
-                    for document_id in chunk.iter().rev() {
-                        let document = documents
-                            .last()
-                            .map_or(false, |(key, _)| (key == document_id))
-                            .then(|| documents.pop().unwrap().1);
-
-                        document_id_sender
-                            .send((document_id.clone(), document))
-                            .unwrap();
-                    }
-
-                    drop(document_id_sender);
-                    Ok(Vec::new())
-                })
                 .each(1..=16, |_| -> Result<_, Error> {
                     let mut results = Vec::new();
                     while let Ok((document_id, document)) = document_id_receiver.recv() {
-                        let (document_is_present, map_result) = if let Some(document) = document {
+                        let map_result = if let Some(document) = document {
                             let document = deserialize_document(&document)?;
 
                             // Call the schema map function
-                            (
-                                true,
-                                self.view
-                                    .map(&document)
-                                    .map_err(bonsaidb_core::Error::from)?,
-                            )
+                            view.map(&document).map_err(bonsaidb_core::Error::from)?
                         } else {
                             // Get multiple didn't return this document ID.
-                            (false, Vec::new())
+                            Vec::new()
                         };
                         let keys: HashSet<OwnedBytes> = map_result
                             .iter()
@@ -256,229 +256,294 @@ impl<'a> DocumentRequest<'a> {
                             .collect();
                         let new_keys = ArcBytes::from(bincode::serialize(&keys)?);
 
-                        results.push((
-                            document_id,
-                            document_is_present,
-                            new_keys,
-                            keys,
-                            map_result,
-                        ));
+                        results.push((document_id, new_keys, keys, map_result));
                     }
+
                     Ok(results)
                 })
                 .run()
             {
-                for (document_id, document_is_present, new_keys, keys, map_result) in result? {
+                for (document_id, new_keys, keys, map_result) in result? {
                     for key in &keys {
-                        all_keys.insert(key.0.clone());
+                        batch.all_keys.insert(key.0.clone());
                     }
-                    document_maps.insert(document_id.clone(), new_keys);
-                    document_keys.insert(document_id.clone(), keys);
+                    batch.document_maps.insert(document_id.clone(), new_keys);
+                    batch.document_keys.insert(document_id.clone(), keys);
                     for mapping in map_result {
-                        let key_mappings = new_mappings
+                        let key_mappings = batch
+                            .new_mappings
                             .entry(ArcBytes::from(mapping.key.to_vec()))
                             .or_insert_with(Vec::default);
                         key_mappings.push(mapping);
                     }
-                    document_statuses.insert(document_id, document_is_present);
                 }
             }
+            mapped_sender.send(batch).unwrap();
+        }
+        drop(mapped_sender);
+        Ok(())
+    }
 
-            // We need to store a record of all the mappings this document produced.
-            let document_map = self
-                .transaction
-                .tree::<Unversioned>(self.document_map_index)
-                .unwrap();
-            let mut maps_to_clear = Vec::new();
-            document_map.modify(
-                chunk.to_vec(),
-                nebari::tree::Operation::CompareSwap(CompareSwap::new(&mut |key, value| {
-                    if let Some(existing_map) = value {
-                        maps_to_clear.push((key.to_owned(), existing_map));
-                    }
-                    let new_map = document_maps.get(key).unwrap();
-                    KeyOperation::Set(new_map.clone())
+    fn update_document_map(
+        document_ids: Vec<ArcBytes<'static>>,
+        document_map: &mut LockedTransactionTree<'_, Unversioned, AnyFile>,
+        document_maps: &BTreeMap<ArcBytes<'static>, ArcBytes<'static>>,
+        mut document_keys: BTreeMap<ArcBytes<'static>, HashSet<OwnedBytes>>,
+        all_keys: &mut BTreeSet<ArcBytes<'static>>,
+    ) -> Result<BTreeMap<ArcBytes<'static>, HashSet<ArcBytes<'static>>>, Error> {
+        // We need to store a record of all the mappings this document produced.
+        let mut maps_to_clear = Vec::new();
+        document_map.modify(
+            document_ids,
+            nebari::tree::Operation::CompareSwap(CompareSwap::new(&mut |key, value| {
+                if let Some(existing_map) = value {
+                    maps_to_clear.push((key.to_owned(), existing_map));
+                }
+                let new_map = document_maps.get(key).unwrap();
+                KeyOperation::Set(new_map.clone())
+            })),
+        )?;
+        let mut view_entries_to_clean = BTreeMap::new();
+        for (document_id, existing_map) in maps_to_clear {
+            let existing_keys = bincode::deserialize::<HashSet<OwnedBytes>>(&existing_map)?;
+            let new_keys = document_keys.remove(&document_id).unwrap();
+            for key in existing_keys.difference(&new_keys) {
+                all_keys.insert(key.clone().0);
+                let key_documents = view_entries_to_clean
+                    .entry(key.clone().0)
+                    .or_insert_with(HashSet::<_, RandomState>::default);
+                key_documents.insert(document_id.clone());
+            }
+        }
+        Ok(view_entries_to_clean)
+    }
+
+    fn update_view_entries(
+        view: &dyn Serialized,
+        map_request: &Map,
+        view_entries: &mut LockedTransactionTree<'_, Unversioned, AnyFile>,
+        all_keys: BTreeSet<ArcBytes<'static>>,
+        view_entries_to_clean: BTreeMap<ArcBytes<'static>, HashSet<ArcBytes<'static>>>,
+        new_mappings: BTreeMap<ArcBytes<'static>, Vec<map::Serialized>>,
+    ) -> Result<(), Error> {
+        let mut updater = ViewEntryUpdater {
+            view,
+            map_request,
+            view_entries_to_clean,
+            new_mappings,
+            result: Ok(()),
+            has_reduce: true,
+        };
+        view_entries
+            .modify(
+                all_keys.into_iter().collect(),
+                Operation::CompareSwap(CompareSwap::new(&mut |key, view_entries| {
+                    updater.compare_swap_view_entry(key, view_entries)
                 })),
+            )
+            .map_err(Error::from)
+            .and(updater.result)
+    }
+
+    fn save_mappings(
+        mapped_receiver: &flume::Receiver<Batch>,
+        view: &dyn Serialized,
+        map_request: &Map,
+        document_map: &mut LockedTransactionTree<'_, Unversioned, AnyFile>,
+        view_entries: &mut LockedTransactionTree<'_, Unversioned, AnyFile>,
+    ) -> Result<(), Error> {
+        while let Ok(Batch {
+            document_ids,
+            document_maps,
+            document_keys,
+            new_mappings,
+            mut all_keys,
+        }) = mapped_receiver.recv()
+        {
+            let view_entries_to_clean = Self::update_document_map(
+                document_ids,
+                document_map,
+                &document_maps,
+                document_keys,
+                &mut all_keys,
             )?;
-            let mut view_entries_to_clean = BTreeMap::new();
-            for (document_id, existing_map) in maps_to_clear {
-                let existing_keys = bincode::deserialize::<HashSet<OwnedBytes>>(&existing_map)?;
-                let new_keys = document_keys.remove(&document_id).unwrap();
-                for key in existing_keys.difference(&new_keys) {
-                    all_keys.insert(key.clone().0);
-                    let key_documents = view_entries_to_clean
-                        .entry(key.clone().0)
-                        .or_insert_with(HashSet::<_, RandomState>::default);
-                    key_documents.insert(document_id.clone());
-                }
-            }
 
-            let mut has_reduce = true;
-            let mut error = None;
-            self.transaction
-                .tree::<Unversioned>(self.view_entries_index)
-                .unwrap()
-                .modify(
-                    all_keys.into_iter().collect(),
-                    Operation::CompareSwap(CompareSwap::new(&mut |key,
-                                                                  view_entries: Option<
-                        ArcBytes<'static>,
-                    >| {
-                        let mut view_entry = view_entries
-                            .and_then(|view_entries| {
-                                bincode::deserialize::<ViewEntry>(&view_entries).ok()
-                            })
-                            .unwrap_or_else(|| ViewEntry {
-                                key: Bytes::from(key.to_vec()),
-                                view_version: self.view.version(),
-                                mappings: vec![],
-                                reduced_value: Bytes::default(),
-                            });
-                        let key = key.to_owned();
-                        if let Some(document_ids) = view_entries_to_clean.remove(&key) {
-                            view_entry
-                                .mappings
-                                .retain(|m| !document_ids.contains(m.source.id.as_ref()));
+            Self::update_view_entries(
+                view,
+                map_request,
+                view_entries,
+                all_keys,
+                view_entries_to_clean,
+                new_mappings,
+            )?;
+        }
+        Ok(())
+    }
 
-                            if view_entry.mappings.is_empty() {
-                                return KeyOperation::Remove;
-                            } else if has_reduce {
-                                let mappings = view_entry
-                                    .mappings
-                                    .iter()
-                                    .map(|m| (&key[..], m.value.as_slice()))
-                                    .collect::<Vec<_>>();
+    pub fn map(&mut self) -> Result<(), Error> {
+        let (batch_sender, batch_receiver) = flume::bounded(1);
+        let (mapped_sender, mapped_receiver) = flume::bounded(1);
 
-                                match self.view.reduce(&mappings, false) {
-                                    Ok(reduced) => {
-                                        view_entry.reduced_value = Bytes::from(reduced);
-                                    }
-                                    Err(view::Error::Core(
-                                        bonsaidb_core::Error::ReduceUnimplemented,
-                                    )) => {
-                                        has_reduce = false;
-                                    }
-                                    Err(other) => {
-                                        error = Some(Error::from(other));
-                                        return KeyOperation::Skip;
-                                    }
-                                }
-                            }
-                        }
-
-                        if let Some(new_mappings) = new_mappings.remove(&key[..]) {
-                            for map::Serialized { source, value, .. } in new_mappings {
-                                // Before altering any data, verify that the key is unique if this is a unique view.
-                                if self.view.unique()
-                                    && !view_entry.mappings.is_empty()
-                                    && view_entry.mappings[0].source.id != source.id
-                                {
-                                    error = Some(Error::Core(
-                                        bonsaidb_core::Error::UniqueKeyViolation {
-                                            view: self.map_request.view_name.clone(),
-                                            conflicting_document: Box::new(source),
-                                            existing_document: Box::new(
-                                                view_entry.mappings[0].source.clone(),
-                                            ),
-                                        },
-                                    ));
-                                    return KeyOperation::Skip;
-                                }
-                                let entry_mapping = EntryMapping { source, value };
-
-                                // attempt to update an existing
-                                // entry for this document, if
-                                // present
-                                let mut found = false;
-                                for mapping in &mut view_entry.mappings {
-                                    if mapping.source.id == entry_mapping.source.id {
-                                        found = true;
-                                        mapping.value = entry_mapping.value.clone();
-                                        break;
-                                    }
-                                }
-
-                                // If an existing mapping wasn't
-                                // found, add it
-                                if !found {
-                                    view_entry.mappings.push(entry_mapping);
-                                }
-                            }
-
-                            // There was a choice to be made here of whether to call
-                            // reduce()  with all of the existing values, or call it with
-                            // rereduce=true passing only the new value and the old stored
-                            // value. In this implementation, it's technically less
-                            // efficient, but we can guarantee that every value has only
-                            // been reduced once, and potentially re-reduced a single-time.
-                            // If we constantly try to update the value to optimize the size
-                            // of `mappings`, the fear is that the value computed may lose
-                            // precision in some contexts over time. Thus, the decision was
-                            // made to always call reduce() with all the mappings within a
-                            // single ViewEntry.
-                            if has_reduce {
-                                let mappings = view_entry
-                                    .mappings
-                                    .iter()
-                                    .map(|m| (key.as_slice(), m.value.as_slice()))
-                                    .collect::<Vec<_>>();
-
-                                match self.view.reduce(&mappings, false) {
-                                    Ok(reduced) => {
-                                        view_entry.reduced_value = Bytes::from(reduced);
-                                    }
-                                    Err(view::Error::Core(
-                                        bonsaidb_core::Error::ReduceUnimplemented,
-                                    )) => {
-                                        has_reduce = false;
-                                    }
-                                    Err(other) => {
-                                        error = Some(Error::from(other));
-                                        return KeyOperation::Skip;
-                                    }
-                                }
-                            }
-                        }
-
-                        let value = bincode::serialize(&view_entry).unwrap();
-                        KeyOperation::Set(ArcBytes::from(value))
-                    })),
-                )?;
-
-            // TODO allow CompareSwap to return an AbortError
-            if let Some(err) = error {
-                return Err(err);
-            }
-
-            let (document_ids, mut is_present): (Vec<_>, VecDeque<_>) =
-                document_statuses.into_iter().unzip();
-            self.transaction
-                .tree::<Unversioned>(self.omitted_entries_index)
-                .unwrap()
-                .modify(
-                    document_ids,
-                    Operation::CompareSwap(CompareSwap::new(&mut |_,
-                                                                  value: Option<
-                        ArcBytes<'static>,
-                    >| {
-                        let is_present = is_present.pop_front().unwrap();
-                        if is_present {
-                            KeyOperation::Remove
-                        } else if value.is_some() {
-                            KeyOperation::Skip
-                        } else {
-                            KeyOperation::Set(ArcBytes::default())
-                        }
-                    })),
-                )?;
+        for result in Parallel::new()
+            .add(|| Self::generate_batches(batch_sender, &self.document_ids, self.documents))
+            .add(|| Self::map_batches(&batch_receiver, mapped_sender, self.view))
+            .add(|| {
+                let mut document_map = self.document_map.lock();
+                let mut view_entries = self.view_entries.lock();
+                Self::save_mappings(
+                    &mapped_receiver,
+                    self.view,
+                    self.map_request,
+                    &mut document_map,
+                    &mut view_entries,
+                )
+            })
+            .run()
+        {
+            result?;
         }
 
         Ok(())
     }
 }
 
+#[derive(Default)]
+struct Batch {
+    document_ids: Vec<ArcBytes<'static>>,
+    document_maps: BTreeMap<ArcBytes<'static>, ArcBytes<'static>>,
+    document_keys: BTreeMap<ArcBytes<'static>, HashSet<OwnedBytes>>,
+    new_mappings: BTreeMap<ArcBytes<'static>, Vec<map::Serialized>>,
+    all_keys: BTreeSet<ArcBytes<'static>>,
+}
+
 impl Keyed<Task> for Mapper {
     fn key(&self) -> Task {
         Task::ViewMap(self.map.clone())
+    }
+}
+
+struct ViewEntryUpdater<'a> {
+    view: &'a dyn Serialized,
+    map_request: &'a Map,
+    view_entries_to_clean: BTreeMap<ArcBytes<'static>, HashSet<ArcBytes<'static>>>,
+    new_mappings: BTreeMap<ArcBytes<'static>, Vec<map::Serialized>>,
+    result: Result<(), Error>,
+    has_reduce: bool,
+}
+
+impl<'a> ViewEntryUpdater<'a> {
+    fn compare_swap_view_entry(
+        &mut self,
+        key: &ArcBytes<'_>,
+        view_entries: Option<ArcBytes<'static>>,
+    ) -> KeyOperation<ArcBytes<'static>> {
+        let mut view_entry = view_entries
+            .and_then(|view_entries| bincode::deserialize::<ViewEntry>(&view_entries).ok())
+            .unwrap_or_else(|| ViewEntry {
+                key: Bytes::from(key.to_vec()),
+                view_version: self.view.version(),
+                mappings: vec![],
+                reduced_value: Bytes::default(),
+            });
+        let key = key.to_owned();
+        if let Some(document_ids) = self.view_entries_to_clean.remove(&key) {
+            view_entry
+                .mappings
+                .retain(|m| !document_ids.contains(m.source.id.as_ref()));
+
+            if view_entry.mappings.is_empty() {
+                return KeyOperation::Remove;
+            } else if self.has_reduce {
+                let mappings = view_entry
+                    .mappings
+                    .iter()
+                    .map(|m| (&key[..], m.value.as_slice()))
+                    .collect::<Vec<_>>();
+
+                match self.view.reduce(&mappings, false) {
+                    Ok(reduced) => {
+                        view_entry.reduced_value = Bytes::from(reduced);
+                    }
+                    Err(view::Error::Core(bonsaidb_core::Error::ReduceUnimplemented)) => {
+                        self.has_reduce = false;
+                    }
+                    Err(other) => {
+                        self.result = Err(Error::from(other));
+                        return KeyOperation::Skip;
+                    }
+                }
+            }
+        }
+
+        if let Some(new_mappings) = self.new_mappings.remove(&key[..]) {
+            for map::Serialized { source, value, .. } in new_mappings {
+                // Before altering any data, verify that the key is unique if this is a unique view.
+                if self.view.unique()
+                    && !view_entry.mappings.is_empty()
+                    && view_entry.mappings[0].source.id != source.id
+                {
+                    self.result = Err(Error::Core(bonsaidb_core::Error::UniqueKeyViolation {
+                        view: self.map_request.view_name.clone(),
+                        conflicting_document: Box::new(source),
+                        existing_document: Box::new(view_entry.mappings[0].source.clone()),
+                    }));
+                    return KeyOperation::Skip;
+                }
+                let entry_mapping = EntryMapping { source, value };
+
+                // attempt to update an existing
+                // entry for this document, if
+                // present
+                let mut found = false;
+                for mapping in &mut view_entry.mappings {
+                    if mapping.source.id == entry_mapping.source.id {
+                        found = true;
+                        mapping.value = entry_mapping.value.clone();
+                        break;
+                    }
+                }
+
+                // If an existing mapping wasn't
+                // found, add it
+                if !found {
+                    view_entry.mappings.push(entry_mapping);
+                }
+            }
+
+            // There was a choice to be made here of whether to call
+            // reduce()  with all of the existing values, or call it with
+            // rereduce=true passing only the new value and the old stored
+            // value. In this implementation, it's technically less
+            // efficient, but we can guarantee that every value has only
+            // been reduced once, and potentially re-reduced a single-time.
+            // If we constantly try to update the value to optimize the size
+            // of `mappings`, the fear is that the value computed may lose
+            // precision in some contexts over time. Thus, the decision was
+            // made to always call reduce() with all the mappings within a
+            // single ViewEntry.
+            if self.has_reduce {
+                let mappings = view_entry
+                    .mappings
+                    .iter()
+                    .map(|m| (key.as_slice(), m.value.as_slice()))
+                    .collect::<Vec<_>>();
+
+                match self.view.reduce(&mappings, false) {
+                    Ok(reduced) => {
+                        view_entry.reduced_value = Bytes::from(reduced);
+                    }
+                    Err(view::Error::Core(bonsaidb_core::Error::ReduceUnimplemented)) => {
+                        self.has_reduce = false;
+                    }
+                    Err(other) => {
+                        self.result = Err(Error::from(other));
+                        return KeyOperation::Skip;
+                    }
+                }
+            }
+        }
+
+        let value = bincode::serialize(&view_entry).unwrap();
+        KeyOperation::Set(ArcBytes::from(value))
     }
 }

--- a/crates/bonsaidb-server/src/config.rs
+++ b/crates/bonsaidb-server/src/config.rs
@@ -201,6 +201,11 @@ impl Builder for ServerConfiguration {
         self
     }
 
+    fn tasks_parallelization(mut self, parallelization: usize) -> Self {
+        self.storage.workers.parallelization = parallelization;
+        self
+    }
+
     fn check_view_integrity_on_open(mut self, check: bool) -> Self {
         self.storage.views.check_integrity_on_open = check;
         self

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -16,7 +16,7 @@ bonsaidb = { path = "../../crates/bonsaidb", version = "0.2.0", features = [
 
 tokio = { version = "1.16.1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
-axum = { version = "0.4" }
+axum = { version = "0.4.7" }
 async-trait = "0.1"
 hyper = { version = "0.14", features = ["http1", "server"] }
 env_logger = "0.9"

--- a/examples/axum/examples/axum.rs
+++ b/examples/axum/examples/axum.rs
@@ -2,7 +2,7 @@
 //! framework should be usable.
 
 use async_trait::async_trait;
-use axum::{extract, routing::get, AddExtensionLayer, Router};
+use axum::{extract, extract::Extension, routing::get, Router};
 use bonsaidb::{
     core::{connection::StorageConnection, keyvalue::KeyValue},
     local::config::Builder,
@@ -33,8 +33,8 @@ impl HttpService for AxumService {
             .route("/", get(uptime_handler))
             .route("/ws", get(upgrade_websocket))
             // Attach the server and the remote address as extractable data for the /ws route
-            .layer(AddExtensionLayer::new(server))
-            .layer(AddExtensionLayer::new(peer.address));
+            .layer(Extension(server))
+            .layer(Extension(peer.address));
 
         if let Err(err) = Http::new()
             .serve_connection(connection, app)

--- a/examples/open-library/.gitignore
+++ b/examples/open-library/.gitignore
@@ -1,0 +1,1 @@
+ol_dump_*.txt

--- a/examples/open-library/Cargo.toml
+++ b/examples/open-library/Cargo.toml
@@ -16,4 +16,4 @@ time = { version = "0.3.7", features = ["serde", "parsing"] }
 flume = "0.10.11"
 futures = '0.3'
 serde_json = "1"
-libflate = "1.1.2"
+clap = { version = "3.0.14", features = ["derive"] }

--- a/examples/open-library/Cargo.toml
+++ b/examples/open-library/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "open-library"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+tokio = { version = "1.16.1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+bonsaidb = { path = "../../crates/bonsaidb", version = "0.2.0", features = [
+    "local",
+    "local-compression",
+] }
+anyhow = "1.0.55"
+time = { version = "0.3.7", features = ["serde", "parsing"] }
+flume = "0.10.11"
+futures = '0.3'
+serde_json = "1"
+libflate = "1.1.2"

--- a/examples/open-library/README.md
+++ b/examples/open-library/README.md
@@ -1,0 +1,38 @@
+# open-library
+
+Data source: <https://openlibrary.org/developers/dumps>
+
+Download:
+
+- all types dump
+- ratings dump
+- reading log dump
+
+Decompress the files and place them next to this README, named:
+
+- ol_dump_all.txt
+- ol_dump_ratingx.txt
+- ol_dump_reading-log.txt
+
+## Data Sizes
+
+Editions, Authors, and Works come from the "all types" export. This file contains extra records that
+are discarded, so there isn't much point to comparing this file's total size
+against the database sizes.
+
+The numbers from below were generated using the 2021-11-30 export.
+
+| File                    | TSV + JSON |     Gzip |
+|-------------------------|------------|----------|
+| ol_dump_all.txt         |   51,447mb | 10,172mb |
+| ol_dump_ratings.txt     |       11mb |      3mb |
+| ol_dump_reading-log.txt |      162mb |     28mb |
+
+All data inserted was batched in transactions of 500k entries.
+
+| Collection | Records    | LZ4 Uncompacted | LZ4 Compacted | Uncompacted | Compacted |
+|------------|------------|-----------------|---------------|-------------|-----------|
+| Authors    |  9,145,605 |       13,316mb |        3,675mb |    23,508mb |   4,159mb |
+| Editions   | 33,102,390 |       74,459mb |       33,155mb |   118,330mb |  38,372mb |
+| Ratings    |    234,571 |           59mb |           54mb |        65mb |      56mb |
+| Works      | 24,010,896 |       40,443mb |       12,082mb |    71,601mb |  13,565mb |

--- a/examples/open-library/examples/open-library.rs
+++ b/examples/open-library/examples/open-library.rs
@@ -653,6 +653,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 #[test]
+#[ignore]
 fn runs() {
     main().unwrap()
 }

--- a/examples/open-library/examples/open-library.rs
+++ b/examples/open-library/examples/open-library.rs
@@ -1,0 +1,410 @@
+use std::{self, collections::BTreeMap, fs::File, io::Read, mem, path::Path};
+
+use bonsaidb::{
+    core::{
+        connection::{Bound, Connection, Range},
+        schema::{Collection, Schema, SerializedCollection},
+        transaction::{Operation, Transaction},
+    },
+    local::{
+        config::{Builder, Compression, StorageConfiguration},
+        Database,
+    },
+};
+use futures::{Future, StreamExt};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use time::{Date, Month};
+
+#[derive(Debug, Schema)]
+#[schema(name = "open-library", collections = [Author, Work, Edition, Rating, ReadingLog])]
+struct OpenLibrary;
+
+#[derive(Debug, Serialize, Deserialize, Collection)]
+#[collection(name = "authors", primary_key = String, natural_id = |author: &Self| Some(author.key.clone()))]
+struct Author {
+    pub key: String,
+    pub name: Option<String>,
+    #[serde(default)]
+    pub alternate_names: Vec<String>,
+    pub bio: Option<TypedValue>,
+    pub birth_date: Option<String>,
+    pub death_date: Option<String>,
+    pub location: Option<String>,
+    pub date: Option<String>,
+    pub entity_type: Option<String>,
+    pub fuller_name: Option<String>,
+    pub personal_name: Option<String>,
+    pub title: Option<String>,
+    #[serde(default)]
+    pub photos: Vec<Option<i64>>,
+    #[serde(default)]
+    pub links: Vec<Link>,
+    pub created: Option<TypedValue>,
+    pub last_modified: TypedValue,
+}
+
+#[derive(Debug, Serialize, Deserialize, Collection)]
+#[collection(name = "editions", primary_key = String, natural_id = |edition: &Self| Some(edition.key.clone()))]
+struct Edition {
+    pub key: String,
+    pub title: Option<String>,
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub authors: Vec<Reference>,
+    #[serde(default)]
+    pub works: Vec<Reference>,
+    #[serde(default)]
+    pub identifiers: BTreeMap<String, Vec<String>>,
+    #[serde(default)]
+    pub isbn_10: Vec<String>,
+    #[serde(default)]
+    pub isbn_13: Vec<String>,
+    #[serde(default)]
+    pub lccn: Vec<String>,
+    #[serde(default)]
+    pub oclc_numbers: Vec<String>,
+    #[serde(default)]
+    pub covers: Vec<Option<i64>>,
+    #[serde(default)]
+    pub links: Vec<Link>,
+    pub by_statement: Option<String>,
+    pub weight: Option<String>,
+    pub edition_name: Option<String>,
+    pub number_of_pages: Option<i32>,
+    pub pagination: Option<String>,
+    pub physical_dimensions: Option<String>,
+    pub physical_format: Option<String>,
+    pub publish_country: Option<String>,
+    pub publish_date: Option<String>,
+    #[serde(default)]
+    pub publish_places: Vec<String>,
+    #[serde(default)]
+    pub publishers: Vec<String>,
+    #[serde(default)]
+    pub contributions: Vec<String>,
+    #[serde(default)]
+    pub dewey_decimal_class: Vec<String>,
+    #[serde(default)]
+    pub genres: Vec<String>,
+    #[serde(default)]
+    pub lc_classifications: Vec<String>,
+    #[serde(default)]
+    pub other_titles: Vec<String>,
+    #[serde(default)]
+    pub series: Vec<String>,
+    #[serde(default)]
+    pub source_records: Vec<Option<String>>,
+    #[serde(default)]
+    pub subjects: Vec<String>,
+    #[serde(default)]
+    pub work_titles: Vec<String>,
+    #[serde(default)]
+    pub table_of_contents: Vec<serde_json::Value>,
+    pub description: Option<TypedValue>,
+    pub first_sentence: Option<TypedValue>,
+    pub notes: Option<TypedValue>,
+    pub created: Option<TypedValue>,
+    pub last_modified: TypedValue,
+}
+
+#[derive(Debug, Serialize, Deserialize, Collection)]
+#[collection(name = "works", primary_key = String, natural_id = |work: &Self| Some(work.key.clone()))]
+struct Work {
+    pub key: String,
+    pub title: Option<String>,
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub authors: Vec<AuthorRole>,
+    #[serde(default)]
+    pub covers: Vec<Option<i64>>,
+    #[serde(default)]
+    pub links: Vec<Link>,
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub lc_classifications: Vec<String>,
+    #[serde(default)]
+    pub subjects: Vec<String>,
+    pub first_publish_date: Option<String>,
+    pub description: Option<TypedValue>,
+    pub notes: Option<TypedValue>,
+    pub created: Option<TypedValue>,
+    pub last_modified: TypedValue,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+enum TypedValue {
+    TypeValue { r#type: String, value: String },
+    Value(String),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct AuthorRole {
+    pub role: Option<String>,
+    pub r#as: Option<String>,
+    pub author: Option<ExternalKey>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+enum Reference {
+    Typed(TypedReference),
+    Key(String),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct TypedReference {
+    pub r#type: Option<String>,
+    pub key: ExternalKey,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+enum ExternalKey {
+    Tagged { key: String },
+    Untagged(String),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Link {
+    pub title: Option<String>,
+    pub url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Collection)]
+#[collection(name = "ratings")]
+struct Rating {
+    pub work_key: String,
+    pub edition_key: String,
+    pub date: Date,
+    pub rating: u8,
+}
+
+impl TryFrom<Vec<String>> for Rating {
+    type Error = anyhow::Error;
+
+    fn try_from(fields: Vec<String>) -> Result<Self, Self::Error> {
+        if fields.len() != 4 {
+            anyhow::bail!("expected 4 fields, got {:?}", fields);
+        }
+
+        let mut fields = fields.into_iter();
+        let work_key = fields.next().unwrap();
+        let edition_key = fields.next().unwrap();
+        let rating = fields.next().unwrap();
+        let rating = rating.parse::<u8>()?;
+        let date = fields.next().unwrap();
+        let mut date_parts = date.split('-');
+        let year = date_parts.next().unwrap().to_owned();
+        let year = year.parse::<i32>()?;
+        let month = date_parts.next().unwrap().to_owned();
+        let month = month.parse::<u8>()?;
+        let month = Month::try_from(month)?;
+        let day = date_parts.next().unwrap().to_owned();
+        let day = day.parse::<u8>()?;
+        let date = Date::from_calendar_date(year, month, day)?;
+
+        Ok(Self {
+            work_key,
+            edition_key,
+            date,
+            rating,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Collection)]
+#[collection(name = "reading-logs")]
+struct ReadingLog {
+    pub work_key: String,
+    pub edition_key: String,
+    pub date: Date,
+    pub shelf: String,
+}
+
+fn parse_tsv(
+    path: impl AsRef<Path> + Send + Sync,
+    output: flume::Sender<Vec<String>>,
+) -> anyhow::Result<()> {
+    let mut file = File::open(path)?;
+    let mut buffer = vec![0; 16192];
+    // let mut file = gzip::Decoder::new(file)?;
+    let mut current_record = vec![Vec::new()];
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            // TODO handle dropping the last record?
+            break;
+        }
+        for &ch in &buffer[..bytes_read] {
+            match ch {
+                b'\t' => {
+                    // Next field
+                    current_record.push(Vec::new());
+                }
+                b'\r' => {}
+                b'\n' => {
+                    // Swap an empty record into the current_record, and send
+                    // the record to the output channel.
+                    let mut record = vec![Vec::new()];
+                    mem::swap(&mut record, &mut current_record);
+                    // Each field should be UTF-8
+                    let record = record
+                        .into_iter()
+                        .map(String::from_utf8)
+                        .collect::<Result<Vec<String>, _>>()?;
+                    output.send(record)?;
+                }
+                other => {
+                    current_record.last_mut().unwrap().push(other);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn import_ratings(database: &Database) -> anyhow::Result<()> {
+    import_from_tsv(
+        "./examples/open-library/ol_dump_ratings.txt",
+        database,
+        |records, database| async move {
+            let mut tx = Transaction::new();
+            for record in records {
+                tx.push(Operation::push_serialized::<Rating>(&Rating::try_from(
+                    record,
+                )?)?);
+            }
+            let inserted = tx.operations.len();
+            database.apply_transaction(tx).await?;
+            Ok(inserted)
+        },
+    )
+    .await
+}
+
+async fn overwrite_serialized<C: SerializedCollection>(
+    tx: &mut Transaction,
+    json: &str,
+) -> anyhow::Result<()>
+where
+    C::Contents: DeserializeOwned,
+{
+    match serde_json::from_str::<C::Contents>(json) {
+        Ok(contents) => {
+            tx.push(Operation::overwrite_serialized::<C>(
+                C::natural_id(&contents).unwrap(),
+                &contents,
+            )?);
+            Ok(())
+        }
+        Err(err) => {
+            anyhow::bail!("Error parsing json {}: {}", err, json);
+        }
+    }
+}
+
+async fn import_primary_data(database: &Database) -> anyhow::Result<()> {
+    import_from_tsv(
+        "./examples/open-library/ol_dump_all.txt",
+        database,
+        |records, database| async move {
+            let mut tx = Transaction::new();
+            for record in &records {
+                match record[0].as_str() {
+                    "/type/author" => overwrite_serialized::<Author>(&mut tx, &record[4]).await?,
+                    "/type/edition" => overwrite_serialized::<Edition>(&mut tx, &record[4]).await?,
+                    "/type/work" => overwrite_serialized::<Work>(&mut tx, &record[4]).await?,
+                    _ => {}
+                }
+            }
+            let inserted = tx.operations.len();
+            database.apply_transaction(tx).await?;
+            Ok(inserted)
+        },
+    )
+    .await
+}
+
+async fn import_from_tsv<
+    Callback: Fn(Vec<Vec<String>>, Database) -> Fut + 'static,
+    Fut: Future<Output = anyhow::Result<usize>>,
+>(
+    path: &'static str,
+    database: &Database,
+    callback: Callback,
+) -> anyhow::Result<()> {
+    const CHUNK_SIZE: usize = 500_000;
+    let (sender, receiver) = flume::bounded(CHUNK_SIZE * 2);
+    std::thread::spawn(move || parse_tsv(path, sender));
+
+    let mut inserted = 0;
+    let mut record_stream = receiver.into_stream().chunks(CHUNK_SIZE);
+    while let Some(records) = record_stream.next().await {
+        inserted += callback(records, database.clone()).await?;
+        println!("Imported records: {}", inserted);
+    }
+
+    Ok(())
+}
+
+/// A paginated version of counting entries. For when you have more data stored
+/// than you have ram...
+// TODO implement an actual count function to avoid loading all the documents
+// https://github.com/khonsulabs/bonsaidb/issues/176
+async fn count<C>(db: &Database) -> anyhow::Result<usize>
+where
+    C: Collection + Unpin,
+    C::PrimaryKey: Default + Unpin,
+{
+    let mut last_id = <C::PrimaryKey as Default>::default();
+    let mut count = 0;
+    loop {
+        let batch = db
+            .collection::<C>()
+            .list(Range {
+                start: Bound::Excluded(last_id),
+                end: Bound::Unbounded,
+            })
+            .limit(1_000_000)
+            .await?;
+        match batch.len() {
+            0 => break,
+            batch_length => {
+                count += batch_length;
+            }
+        }
+
+        last_id = batch.last().unwrap().header.id.deserialize()?;
+    }
+    Ok(count)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let db = Database::open::<OpenLibrary>(
+        StorageConfiguration::new("open-library.bonsaidb").default_compression(Compression::Lz4),
+    )
+    .await?;
+
+    let primary_import = import_primary_data(&db);
+    let ratings_import = import_ratings(&db);
+    tokio::try_join!(primary_import, ratings_import)?;
+
+    println!("Compacting");
+    db.compact().await?;
+    println!("Done compacting");
+
+    println!("Total authors: {}", count::<Author>(&db).await?);
+    println!("Total works: {}", count::<Work>(&db).await?);
+    println!("Total editions: {}", count::<Edition>(&db).await?);
+    println!("Total ratings: {}", count::<Rating>(&db).await?);
+
+    Ok(())
+}
+
+#[test]
+fn runs() {
+    main().unwrap()
+}


### PR DESCRIPTION
This is a new example that will turn into a few things, I think.
Initially, it's a way for me to test a large amount of data. The README
shows the data sizes being tested. It served as a way for me to feel
confident in its behavior with a large, organic dataset.

To adequately do that, more than just counting the records needs to
happen. Two uses come to mind:

- Benchmarks for querying various aspects of the dataset, with other
  implementations for other database.
- Creating a command-line interface that can be used to browse/search
  the database. The way this is written could serve as a good larger
  example.

Of note, running this multiple times causes the ratings set to be
appended to each time. This is because the dataset doesn't have a
primary key for each row, most likely due to it being anonymized.