### PR TITLE
Add Token-based Authentication

### DIFF
--- a/.rustme/docs.md
+++ b/.rustme/docs.md
@@ -83,6 +83,8 @@ bonsaidb = { version = "*", features = "full" }
 - `cli`: Enables the `bonsaidb` executable.
 - `password-hashing`: Enables the ability to use password authentication using
   Argon2 via `AnyConnection`.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 All other feature flags, listed below, affect each crate individually, but can
 be safely combined.
@@ -107,6 +109,8 @@ All Cargo features that affect local databases:
 - `instrument`: Enables instrumenting with `tracing`.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ### BonsaiDb server
 
@@ -130,6 +134,8 @@ All Cargo features that affect networked servers:
 - `websockets`: Enables `WebSocket` support.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ### Client for accessing a BonsaiDb server
 
@@ -148,3 +154,5 @@ All Cargo features that affect networked clients:
 - `websockets`: Enables `WebSocket` support for `bonsaidb-client`.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Shape { sides: 3 }.push_into(&db)?;
 And query data using the Map-Reduce-powered view:
 
 ```rust,ignore
-let triangles = db.view::<ShapesByNumberOfSides>().with_key(3).query()?;
+let triangles = db.view::<ShapesByNumberOfSides>().with_key(&3).query()?;
 println!("Number of triangles: {}", triangles.len());
 ```
 
@@ -115,6 +115,8 @@ bonsaidb = { version = "*", features = "full" }
 - `cli`: Enables the `bonsaidb` executable.
 - `password-hashing`: Enables the ability to use password authentication using
   Argon2 via `AnyConnection`.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 All other feature flags, listed below, affect each crate individually, but can
 be safely combined.
@@ -139,6 +141,8 @@ All Cargo features that affect local databases:
 - `instrument`: Enables instrumenting with `tracing`.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ### BonsaiDb server
 
@@ -162,6 +166,8 @@ All Cargo features that affect networked servers:
 - `websockets`: Enables `WebSocket` support.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ### Client for accessing a BonsaiDb server
 
@@ -180,6 +186,8 @@ All Cargo features that affect networked clients:
 - `websockets`: Enables `WebSocket` support for `bonsaidb-client`.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ## Developing BonsaiDb
 

--- a/crates/bonsaidb-client/Cargo.toml
+++ b/crates/bonsaidb-client/Cargo.toml
@@ -20,6 +20,7 @@ trusted-dns = ["fabruic/trust-dns"]
 test-util = []
 tracing = ["pot/tracing"]
 password-hashing = ["bonsaidb-core/password-hashing"]
+token-authentication = ["bonsaidb-core/token-authentication"]
 included-from-omnibus = []
 
 [dependencies]

--- a/crates/bonsaidb-client/README.md
+++ b/crates/bonsaidb-client/README.md
@@ -49,6 +49,8 @@ By default, the `full` feature is enabled.
 - `websockets`: Enables `WebSocket` support for `bonsaidb-client`.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 - `tracing`: Enables `tracing` annotations on some functions and dependencies.
 
 ## Open-source Licenses

--- a/crates/bonsaidb-client/client-feature-flags.md
+++ b/crates/bonsaidb-client/client-feature-flags.md
@@ -8,4 +8,6 @@ By default, the `full` feature is enabled.
 - `websockets`: Enables `WebSocket` support for `bonsaidb-client`.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 - `tracing`: Enables `tracing` annotations on some functions and dependencies.

--- a/crates/bonsaidb-client/src/client.rs
+++ b/crates/bonsaidb-client/src/client.rs
@@ -693,6 +693,7 @@ impl AsyncStorageConnection for Client {
             .await?)
     }
 
+    #[cfg(any(feature = "token-authentication", feature = "password-hashing"))]
     async fn authenticate(
         &self,
         authentication: Authentication,

--- a/crates/bonsaidb-client/src/client.rs
+++ b/crates/bonsaidb-client/src/client.rs
@@ -12,8 +12,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-#[cfg(feature = "password-hashing")]
-use bonsaidb_core::connection::Authentication;
 use bonsaidb_core::{
     admin::{Admin, ADMIN_DATABASE_NAME},
     api::{self, Api},
@@ -696,7 +694,7 @@ impl AsyncStorageConnection for Client {
     #[cfg(any(feature = "token-authentication", feature = "password-hashing"))]
     async fn authenticate(
         &self,
-        authentication: Authentication,
+        authentication: bonsaidb_core::connection::Authentication,
     ) -> Result<Self::Authenticated, bonsaidb_core::Error> {
         let session = self
             .send_api_request_async(&bonsaidb_core::networking::Authenticate { authentication })

--- a/crates/bonsaidb-client/src/client.rs
+++ b/crates/bonsaidb-client/src/client.rs
@@ -693,17 +693,12 @@ impl AsyncStorageConnection for Client {
             .await?)
     }
 
-    #[cfg(feature = "password-hashing")]
-    async fn authenticate<'user, U: Nameable<'user, u64> + Send + Sync>(
+    async fn authenticate(
         &self,
-        user: U,
         authentication: Authentication,
     ) -> Result<Self::Authenticated, bonsaidb_core::Error> {
         let session = self
-            .send_api_request_async(&bonsaidb_core::networking::Authenticate {
-                user: user.name()?.into_owned(),
-                authentication,
-            })
+            .send_api_request_async(&bonsaidb_core::networking::Authenticate { authentication })
             .await?;
         Ok(Self {
             data: self.data.clone(),

--- a/crates/bonsaidb-client/src/client/remote_database.rs
+++ b/crates/bonsaidb-client/src/client/remote_database.rs
@@ -3,7 +3,7 @@ use std::{ops::Deref, sync::Arc};
 use async_trait::async_trait;
 use bonsaidb_core::{
     connection::{
-        AccessPolicy, AsyncConnection, AsyncLowLevelConnection, HasSession, Range,
+        AccessPolicy, AsyncConnection, AsyncLowLevelConnection, HasSchema, HasSession, Range,
         SerializedQueryKey, Session, Sort,
     },
     document::{DocumentId, Header, OwnedDocument},
@@ -113,10 +113,6 @@ impl AsyncConnection for RemoteDatabase {
 
 #[async_trait]
 impl AsyncLowLevelConnection for RemoteDatabase {
-    fn schematic(&self) -> &Schematic {
-        &self.schema
-    }
-
     async fn apply_transaction(
         &self,
         transaction: Transaction,
@@ -317,5 +313,11 @@ impl AsyncLowLevelConnection for RemoteDatabase {
                 access_policy,
             })
             .await?)
+    }
+}
+
+impl HasSchema for RemoteDatabase {
+    fn schematic(&self) -> &Schematic {
+        &self.schema
     }
 }

--- a/crates/bonsaidb-client/src/client/sync.rs
+++ b/crates/bonsaidb-client/src/client/sync.rs
@@ -108,6 +108,7 @@ impl StorageConnection for Client {
         })?)
     }
 
+    #[cfg(any(feature = "token-authentication", feature = "password-hashing"))]
     fn authenticate(
         &self,
         authentication: bonsaidb_core::connection::Authentication,

--- a/crates/bonsaidb-client/src/client/sync.rs
+++ b/crates/bonsaidb-client/src/client/sync.rs
@@ -18,7 +18,7 @@ use bonsaidb_core::{
         ReduceGrouped, SubscribeTo, UnsubscribeFrom,
     },
     pubsub::{AsyncSubscriber, PubSub, Receiver, Subscriber},
-    schema::{view::map, CollectionName, Schematic, ViewName},
+    schema::{view::map, CollectionName, ViewName},
 };
 use futures::Future;
 use tokio::{
@@ -108,16 +108,12 @@ impl StorageConnection for Client {
         })?)
     }
 
-    #[cfg(feature = "password-hashing")]
-    fn authenticate<'user, U: bonsaidb_core::schema::Nameable<'user, u64> + Send + Sync>(
+    fn authenticate(
         &self,
-        user: U,
         authentication: bonsaidb_core::connection::Authentication,
     ) -> Result<Self::Authenticated, bonsaidb_core::Error> {
-        let session = self.send_api_request(&bonsaidb_core::networking::Authenticate {
-            user: user.name()?.into_owned(),
-            authentication,
-        })?;
+        let session =
+            self.send_api_request(&bonsaidb_core::networking::Authenticate { authentication })?;
         Ok(Self {
             data: self.data.clone(),
             session: Arc::new(session),
@@ -249,10 +245,6 @@ impl Connection for RemoteDatabase {
 }
 
 impl LowLevelConnection for RemoteDatabase {
-    fn schematic(&self) -> &Schematic {
-        &self.schema
-    }
-
     fn apply_transaction(
         &self,
         transaction: bonsaidb_core::transaction::Transaction,

--- a/crates/bonsaidb-core/Cargo.toml
+++ b/crates/bonsaidb-core/Cargo.toml
@@ -20,6 +20,7 @@ actionable-traits = []
 instrument = ["pot/tracing"]
 encryption = []
 password-hashing = []
+token-authentication = ["blake3", "rand"]
 included-from-omnibus = ["bonsaidb-macros/omnibus-path"]
 included-from-server = ["bonsaidb-macros/server-path"]
 included-from-local = ["bonsaidb-macros/local-path"]
@@ -34,7 +35,6 @@ async-trait = "0.1"
 uuid = { version = "0.8", features = ["v4", "serde"], optional = true }
 thiserror = "1"
 sha2 = "0.10"
-blake3 = "1.3.1"
 futures = { version = "0.3" }
 tokio = { version = "1.16.1", features = ["time"], optional = true }
 num-traits = "0.2"
@@ -49,7 +49,8 @@ arc-bytes = { version = "0.3.3", features = ["serde"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 num_cpus = { version = "1.13.1", optional = true }
 tinyvec = { version = "1.5.1", features = ["alloc"] }
-rand = "0.8.5"
+blake3 = { version = "1.3.1", optional = true }
+rand = { version = "0.8.5", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/crates/bonsaidb-core/Cargo.toml
+++ b/crates/bonsaidb-core/Cargo.toml
@@ -34,6 +34,7 @@ async-trait = "0.1"
 uuid = { version = "0.8", features = ["v4", "serde"], optional = true }
 thiserror = "1"
 sha2 = "0.10"
+blake3 = "1.3.1"
 futures = { version = "0.3" }
 tokio = { version = "1.16.1", features = ["time"], optional = true }
 num-traits = "0.2"
@@ -48,6 +49,7 @@ arc-bytes = { version = "0.3.3", features = ["serde"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 num_cpus = { version = "1.13.1", optional = true }
 tinyvec = { version = "1.5.1", features = ["alloc"] }
+rand = "0.8.5"
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/crates/bonsaidb-core/src/admin/authentication_token.rs
+++ b/crates/bonsaidb-core/src/admin/authentication_token.rs
@@ -1,0 +1,159 @@
+use arc_bytes::serde::Bytes;
+use rand::{thread_rng, Rng};
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+use crate::{
+    admin::authentication_token,
+    connection::{
+        AsyncConnection, Connection, IdentityId, IdentityReference, SensitiveBytes,
+        TokenChallengeAlgorithm,
+    },
+    define_basic_unique_mapped_view,
+    document::{CollectionDocument, Emit},
+    key::time::TimestampAsNanoseconds,
+    schema::{Collection, SerializedCollection},
+};
+
+#[derive(Collection, Clone, Serialize, Deserialize, Debug)]
+#[collection(name = "authentication-tokens", authority = "bonsaidb", core = crate)]
+pub struct AuthenticationToken {
+    pub identity: IdentityId,
+    pub token: SensitiveBytes,
+    pub created_at: TimestampAsNanoseconds,
+}
+
+impl AuthenticationToken {
+    fn random(identity: IdentityId) -> (u64, Self) {
+        let mut rng = thread_rng();
+        let id = rng.gen();
+        let token = SensitiveBytes(Bytes::from(vec![rng.gen(); 32]));
+        (
+            id,
+            Self {
+                identity,
+                token,
+                created_at: TimestampAsNanoseconds::now(),
+            },
+        )
+    }
+
+    pub fn create<C: Connection>(
+        identity: &IdentityReference<'_>,
+        database: &C,
+    ) -> Result<CollectionDocument<Self>, crate::Error> {
+        let identity_id = identity
+            .resolve(database)?
+            .ok_or(crate::Error::InvalidCredentials)?;
+        loop {
+            let (id, token) = Self::random(identity_id);
+            match token.insert_into(&id, database) {
+                Err(err)
+                    if err
+                        .error
+                        .is_unique_key_error::<authentication_token::ByToken, _>(database)
+                        || err.error.conflicting_document::<Self>().is_some() =>
+                {
+                    continue
+                }
+                other => break other.map_err(|err| err.error),
+            }
+        }
+    }
+
+    pub async fn create_async<C: AsyncConnection>(
+        identity: IdentityReference<'_>,
+        database: &C,
+    ) -> Result<CollectionDocument<Self>, crate::Error> {
+        let identity_id = identity
+            .resolve_async(database)
+            .await?
+            .ok_or(crate::Error::InvalidCredentials)?;
+        loop {
+            let (id, token) = Self::random(identity_id);
+            match token.insert_into_async(&id, database).await {
+                Err(err)
+                    if err
+                        .error
+                        .is_unique_key_error::<authentication_token::ByToken, _>(database)
+                        || err.error.conflicting_document::<Self>().is_some() =>
+                {
+                    continue
+                }
+                other => break other.map_err(|err| err.error),
+            }
+        }
+    }
+
+    pub fn validate_challenge(
+        &self,
+        algorithm: TokenChallengeAlgorithm,
+        server_timestamp: TimestampAsNanoseconds,
+        nonce: &[u8],
+        hash: &[u8],
+    ) -> Result<(), crate::Error> {
+        let TokenChallengeAlgorithm::Blake3 = algorithm;
+        let computed_hash =
+            Self::compute_challenge_response_blake3(&self.token, nonce, server_timestamp);
+        let hash: [u8; blake3::OUT_LEN] = hash
+            .try_into()
+            .map_err(|_| crate::Error::InvalidCredentials)?;
+
+        if computed_hash == hash {
+            Ok(())
+        } else {
+            Err(crate::Error::InvalidCredentials)
+        }
+    }
+
+    #[must_use]
+    pub fn compute_challenge_response_blake3(
+        token: &SensitiveBytes,
+        nonce: &[u8],
+        timestamp: TimestampAsNanoseconds,
+    ) -> blake3::Hash {
+        let context = format!("bonsaidb {timestamp} token-challenge");
+        let mut key = blake3::derive_key(&context, &token.0);
+        let hash = blake3::keyed_hash(&key, nonce);
+        key.zeroize();
+        hash
+    }
+
+    pub fn check_request_time(
+        request_time: TimestampAsNanoseconds,
+        request_time_check: &[u8],
+        algorithm: TokenChallengeAlgorithm,
+        token: &SensitiveBytes,
+    ) -> Result<(), crate::Error> {
+        match algorithm {
+            TokenChallengeAlgorithm::Blake3 => {
+                let request_time_check: [u8; blake3::OUT_LEN] = request_time_check
+                    .try_into()
+                    .map_err(|_| crate::Error::InvalidCredentials)?;
+                if Self::compute_request_time_hash_blake3(request_time, token) == request_time_check
+                {
+                    Ok(())
+                } else {
+                    Err(crate::Error::InvalidCredentials)
+                }
+            }
+        }
+    }
+
+    pub(crate) fn compute_request_time_hash_blake3(
+        request_time: TimestampAsNanoseconds,
+        private_token: &SensitiveBytes,
+    ) -> blake3::Hash {
+        let context = format!("bonsaidb {request_time} token-authentication");
+        let mut key = blake3::derive_key(&context, &private_token.0);
+        let hash = blake3::keyed_hash(&key, &request_time.representation().to_be_bytes());
+        key.zeroize();
+        hash
+    }
+}
+
+impl AuthenticationToken {}
+
+define_basic_unique_mapped_view! {
+    ByToken, AuthenticationToken, 0, "by-token", SensitiveBytes, |token: CollectionDocument<AuthenticationToken>| token.header.emit_key(token.contents.token)
+}

--- a/crates/bonsaidb-core/src/admin/authentication_token.rs
+++ b/crates/bonsaidb-core/src/admin/authentication_token.rs
@@ -1,18 +1,11 @@
-use arc_bytes::serde::Bytes;
-use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
-use zeroize::Zeroize;
 
 use crate::{
-    admin::authentication_token,
-    connection::{
-        AsyncConnection, Connection, IdentityId, IdentityReference, SensitiveBytes,
-        TokenChallengeAlgorithm,
-    },
+    connection::{IdentityId, SensitiveBytes},
     define_basic_unique_mapped_view,
     document::{CollectionDocument, Emit},
     key::time::TimestampAsNanoseconds,
-    schema::{Collection, SerializedCollection},
+    schema::Collection,
 };
 
 #[derive(Collection, Clone, Serialize, Deserialize, Debug)]
@@ -23,132 +16,153 @@ pub struct AuthenticationToken {
     pub created_at: TimestampAsNanoseconds,
 }
 
-impl AuthenticationToken {
-    fn random(identity: IdentityId) -> (u64, Self) {
-        let mut rng = thread_rng();
-        let id = rng.gen();
-        let token = SensitiveBytes(Bytes::from(vec![rng.gen(); 32]));
-        (
-            id,
-            Self {
-                identity,
-                token,
-                created_at: TimestampAsNanoseconds::now(),
-            },
-        )
-    }
+#[cfg(feature = "token-authentication")]
+mod implementation {
+    use arc_bytes::serde::Bytes;
+    use rand::{thread_rng, Rng};
+    use zeroize::Zeroize;
 
-    pub fn create<C: Connection>(
-        identity: &IdentityReference<'_>,
-        database: &C,
-    ) -> Result<CollectionDocument<Self>, crate::Error> {
-        let identity_id = identity
-            .resolve(database)?
-            .ok_or(crate::Error::InvalidCredentials)?;
-        loop {
-            let (id, token) = Self::random(identity_id);
-            match token.insert_into(&id, database) {
-                Err(err)
-                    if err
-                        .error
-                        .is_unique_key_error::<authentication_token::ByToken, _>(database)
-                        || err.error.conflicting_document::<Self>().is_some() =>
-                {
-                    continue
-                }
-                other => break other.map_err(|err| err.error),
-            }
+    use super::AuthenticationToken;
+    use crate::{
+        admin::authentication_token,
+        connection::{
+            AsyncConnection, Connection, IdentityId, IdentityReference, SensitiveBytes,
+            TokenChallengeAlgorithm,
+        },
+        document::CollectionDocument,
+        key::time::TimestampAsNanoseconds,
+        schema::SerializedCollection,
+    };
+
+    impl AuthenticationToken {
+        fn random(identity: IdentityId) -> (u64, Self) {
+            let mut rng = thread_rng();
+            let id = rng.gen();
+            let token = SensitiveBytes(Bytes::from(vec![rng.gen(); 32]));
+            (
+                id,
+                Self {
+                    identity,
+                    token,
+                    created_at: TimestampAsNanoseconds::now(),
+                },
+            )
         }
-    }
 
-    pub async fn create_async<C: AsyncConnection>(
-        identity: IdentityReference<'_>,
-        database: &C,
-    ) -> Result<CollectionDocument<Self>, crate::Error> {
-        let identity_id = identity
-            .resolve_async(database)
-            .await?
-            .ok_or(crate::Error::InvalidCredentials)?;
-        loop {
-            let (id, token) = Self::random(identity_id);
-            match token.insert_into_async(&id, database).await {
-                Err(err)
-                    if err
-                        .error
-                        .is_unique_key_error::<authentication_token::ByToken, _>(database)
-                        || err.error.conflicting_document::<Self>().is_some() =>
-                {
-                    continue
-                }
-                other => break other.map_err(|err| err.error),
-            }
-        }
-    }
-
-    pub fn validate_challenge(
-        &self,
-        algorithm: TokenChallengeAlgorithm,
-        server_timestamp: TimestampAsNanoseconds,
-        nonce: &[u8],
-        hash: &[u8],
-    ) -> Result<(), crate::Error> {
-        let TokenChallengeAlgorithm::Blake3 = algorithm;
-        let computed_hash =
-            Self::compute_challenge_response_blake3(&self.token, nonce, server_timestamp);
-        let hash: [u8; blake3::OUT_LEN] = hash
-            .try_into()
-            .map_err(|_| crate::Error::InvalidCredentials)?;
-
-        if computed_hash == hash {
-            Ok(())
-        } else {
-            Err(crate::Error::InvalidCredentials)
-        }
-    }
-
-    #[must_use]
-    pub fn compute_challenge_response_blake3(
-        token: &SensitiveBytes,
-        nonce: &[u8],
-        timestamp: TimestampAsNanoseconds,
-    ) -> blake3::Hash {
-        let context = format!("bonsaidb {timestamp} token-challenge");
-        let mut key = blake3::derive_key(&context, &token.0);
-        let hash = blake3::keyed_hash(&key, nonce);
-        key.zeroize();
-        hash
-    }
-
-    pub fn check_request_time(
-        request_time: TimestampAsNanoseconds,
-        request_time_check: &[u8],
-        algorithm: TokenChallengeAlgorithm,
-        token: &SensitiveBytes,
-    ) -> Result<(), crate::Error> {
-        match algorithm {
-            TokenChallengeAlgorithm::Blake3 => {
-                let request_time_check: [u8; blake3::OUT_LEN] = request_time_check
-                    .try_into()
-                    .map_err(|_| crate::Error::InvalidCredentials)?;
-                if Self::compute_request_time_hash_blake3(request_time, token) == request_time_check
-                {
-                    Ok(())
-                } else {
-                    Err(crate::Error::InvalidCredentials)
+        pub fn create<C: Connection>(
+            identity: &IdentityReference<'_>,
+            database: &C,
+        ) -> Result<CollectionDocument<Self>, crate::Error> {
+            let identity_id = identity
+                .resolve(database)?
+                .ok_or(crate::Error::InvalidCredentials)?;
+            loop {
+                let (id, token) = Self::random(identity_id);
+                match token.insert_into(&id, database) {
+                    Err(err)
+                        if err
+                            .error
+                            .is_unique_key_error::<authentication_token::ByToken, _>(database)
+                            || err.error.conflicting_document::<Self>().is_some() =>
+                    {
+                        continue
+                    }
+                    other => break other.map_err(|err| err.error),
                 }
             }
         }
-    }
 
-    pub(crate) fn compute_request_time_hash_blake3(
-        request_time: TimestampAsNanoseconds,
-        private_token: &SensitiveBytes,
-    ) -> blake3::Hash {
-        let context = format!("bonsaidb {request_time} token-authentication");
-        let mut key = blake3::derive_key(&context, &private_token.0);
-        let hash = blake3::keyed_hash(&key, &request_time.representation().to_be_bytes());
-        key.zeroize();
-        hash
+        pub async fn create_async<C: AsyncConnection>(
+            identity: IdentityReference<'_>,
+            database: &C,
+        ) -> Result<CollectionDocument<Self>, crate::Error> {
+            let identity_id = identity
+                .resolve_async(database)
+                .await?
+                .ok_or(crate::Error::InvalidCredentials)?;
+            loop {
+                let (id, token) = Self::random(identity_id);
+                match token.insert_into_async(&id, database).await {
+                    Err(err)
+                        if err
+                            .error
+                            .is_unique_key_error::<authentication_token::ByToken, _>(database)
+                            || err.error.conflicting_document::<Self>().is_some() =>
+                    {
+                        continue
+                    }
+                    other => break other.map_err(|err| err.error),
+                }
+            }
+        }
+
+        pub fn validate_challenge(
+            &self,
+            algorithm: TokenChallengeAlgorithm,
+            server_timestamp: TimestampAsNanoseconds,
+            nonce: &[u8],
+            hash: &[u8],
+        ) -> Result<(), crate::Error> {
+            let TokenChallengeAlgorithm::Blake3 = algorithm;
+            let computed_hash =
+                Self::compute_challenge_response_blake3(&self.token, nonce, server_timestamp);
+            let hash: [u8; blake3::OUT_LEN] = hash
+                .try_into()
+                .map_err(|_| crate::Error::InvalidCredentials)?;
+
+            if computed_hash == hash {
+                Ok(())
+            } else {
+                Err(crate::Error::InvalidCredentials)
+            }
+        }
+
+        #[must_use]
+        pub fn compute_challenge_response_blake3(
+            token: &SensitiveBytes,
+            nonce: &[u8],
+            timestamp: TimestampAsNanoseconds,
+        ) -> blake3::Hash {
+            let context = format!("bonsaidb {timestamp} token-challenge");
+            let mut key = blake3::derive_key(&context, &token.0);
+            let hash = blake3::keyed_hash(&key, nonce);
+            key.zeroize();
+            hash
+        }
+
+        pub fn check_request_time(
+            request_time: TimestampAsNanoseconds,
+            request_time_check: &[u8],
+            algorithm: TokenChallengeAlgorithm,
+            token: &SensitiveBytes,
+        ) -> Result<(), crate::Error> {
+            match algorithm {
+                TokenChallengeAlgorithm::Blake3 => {
+                    let request_time_check: [u8; blake3::OUT_LEN] =
+                        request_time_check
+                            .try_into()
+                            .map_err(|_| crate::Error::InvalidCredentials)?;
+                    if Self::compute_request_time_hash_blake3(request_time, token)
+                        == request_time_check
+                    {
+                        Ok(())
+                    } else {
+                        Err(crate::Error::InvalidCredentials)
+                    }
+                }
+            }
+        }
+
+        pub(crate) fn compute_request_time_hash_blake3(
+            request_time: TimestampAsNanoseconds,
+            private_token: &SensitiveBytes,
+        ) -> blake3::Hash {
+            let context = format!("bonsaidb {request_time} token-authentication");
+            let mut key = blake3::derive_key(&context, &private_token.0);
+            let hash = blake3::keyed_hash(&key, &request_time.representation().to_be_bytes());
+            key.zeroize();
+            hash
+        }
     }
 }
 

--- a/crates/bonsaidb-core/src/admin/mod.rs
+++ b/crates/bonsaidb-core/src/admin/mod.rs
@@ -1,6 +1,8 @@
 use crate::schema::Schema;
 
 #[doc(hidden)]
+pub mod authentication_token;
+#[doc(hidden)]
 pub mod database;
 #[doc(hidden)]
 pub mod group;
@@ -9,11 +11,14 @@ pub mod role;
 #[doc(hidden)]
 pub mod user;
 
-pub use self::{database::Database, group::PermissionGroup, role::Role, user::User};
+pub use self::{
+    authentication_token::AuthenticationToken, database::Database, group::PermissionGroup,
+    role::Role, user::User,
+};
 
 /// The BonsaiDb administration schema.
 #[derive(Debug, Schema)]
-#[schema(name = "bonsaidb-admin", authority = "khonsulabs", collections = [Database, PermissionGroup, Role, User], core = crate)]
+#[schema(name = "bonsaidb-admin", authority = "khonsulabs", collections = [Database, PermissionGroup, Role, User, AuthenticationToken], core = crate)]
 pub struct Admin;
 
 /// The name of the admin database.

--- a/crates/bonsaidb-core/src/connection.rs
+++ b/crates/bonsaidb-core/src/connection.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Borrow, marker::PhantomData, ops::Deref, sync::Arc};
+use std::{
+    borrow::Borrow, convert::Infallible, marker::PhantomData, ops::Deref, string::FromUtf8Error,
+    sync::Arc,
+};
 
 use actionable::{Action, Identifier};
 use arc_bytes::serde::Bytes;
@@ -8,8 +11,9 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 use crate::{
+    admin::{AuthenticationToken, Role, User},
     document::{CollectionDocument, CollectionHeader, Document, HasHeader, Header, OwnedDocument},
-    key::{IntoPrefixRange, Key, KeyEncoding},
+    key::{time::TimestampAsNanoseconds, IntoPrefixRange, Key, KeyEncoding},
     permissions::Permissions,
     schema::{
         self,
@@ -24,7 +28,7 @@ mod lowlevel;
 
 pub use self::{
     has_session::HasSession,
-    lowlevel::{AsyncLowLevelConnection, LowLevelConnection},
+    lowlevel::{AsyncLowLevelConnection, HasSchema, LowLevelConnection},
 };
 
 /// A connection to a database's [`Schema`](schema::Schema), giving access to
@@ -3049,21 +3053,65 @@ pub trait StorageConnection: HasSession + Sized + Send + Sync {
         password: SensitiveString,
     ) -> Result<(), crate::Error>;
 
-    /// Authenticates as a user with a authentication method.
-    #[cfg(feature = "password-hashing")]
-    fn authenticate<'user, U: Nameable<'user, u64> + Send + Sync>(
+    /// Authenticates using the active session, returning a connection with a
+    /// new session upon success. The existing connection will remain usable
+    /// with the existing authentication, if any.
+    fn authenticate(
         &self,
-        user: U,
         authentication: Authentication,
     ) -> Result<Self::Authenticated, crate::Error>;
 
     /// Assumes the `identity`. If successful, the returned instance will have
-    /// the merged permissions of the current authentication session and the
-    /// permissions from `identity`.
+    ///  the permissions from `identity`.
     fn assume_identity(
         &self,
         identity: IdentityReference<'_>,
     ) -> Result<Self::Authenticated, crate::Error>;
+
+    /// Authenticates using an
+    /// [`AuthenticationToken`](crate::admin::AuthenticationToken). If
+    ///  successful, the returned instance will have the permissions from
+    ///  `identity`.
+    fn authenticate_with_token(
+        &self,
+        id: u64,
+        token: &SensitiveBytes,
+    ) -> Result<<Self::Authenticated as StorageConnection>::Authenticated, crate::Error> {
+        let challenge_session = self.authenticate(Authentication::token(id, token)?)?;
+        match challenge_session
+            .session()
+            .map(|session| &session.authentication)
+        {
+            Some(SessionAuthentication::TokenChallenge {
+                algorithm: TokenChallengeAlgorithm::Blake3,
+                nonce,
+                server_timestamp,
+                ..
+            }) => {
+                let response = AuthenticationToken::compute_challenge_response_blake3(
+                    token,
+                    nonce,
+                    *server_timestamp,
+                );
+                challenge_session.authenticate(Authentication::TokenChallengeResponse(Bytes::from(
+                    response.as_bytes().to_vec(),
+                )))
+            }
+            _ => Err(crate::Error::InvalidCredentials),
+        }
+    }
+
+    /// Authenticates a [`User`](crate::admin::User) using a password. If
+    ///  successful, the returned instance will have the permissions from
+    ///  `identity`.
+    #[cfg(feature = "password-hashing")]
+    fn authenticate_with_password<'name, User: Nameable<'name, u64>>(
+        &self,
+        user: User,
+        password: SensitiveString,
+    ) -> Result<Self::Authenticated, crate::Error> {
+        self.authenticate(Authentication::password(user, password)?)
+    }
 
     /// Adds a user to a permission group.
     fn add_permission_group_to_user<
@@ -3195,13 +3243,62 @@ pub trait AsyncStorageConnection: HasSession + Sized + Send + Sync {
         password: SensitiveString,
     ) -> Result<(), crate::Error>;
 
-    /// Authenticates as a user with a authentication method.
-    #[cfg(feature = "password-hashing")]
-    async fn authenticate<'user, U: Nameable<'user, u64> + Send + Sync>(
+    /// Authenticates using an
+    /// [`AuthenticationToken`](crate::admin::AuthenticationToken). If
+    ///  successful, the returned instance will have the permissions from
+    ///  `identity`.
+    async fn authenticate(
         &self,
-        user: U,
         authentication: Authentication,
     ) -> Result<Self::Authenticated, crate::Error>;
+
+    /// Authenticates using an
+    /// [`AuthenticationToken`](crate::admin::AuthenticationToken). If
+    ///  successful, the returned instance will have the permissions from
+    ///  `identity`.
+    async fn authenticate_with_token(
+        &self,
+        id: u64,
+        token: &SensitiveBytes,
+    ) -> Result<<Self::Authenticated as AsyncStorageConnection>::Authenticated, crate::Error> {
+        let challenge_session = self.authenticate(Authentication::token(id, token)?).await?;
+        match challenge_session
+            .session()
+            .map(|session| &session.authentication)
+        {
+            Some(SessionAuthentication::TokenChallenge {
+                algorithm: TokenChallengeAlgorithm::Blake3,
+                nonce,
+                server_timestamp,
+                ..
+            }) => {
+                let response = AuthenticationToken::compute_challenge_response_blake3(
+                    token,
+                    nonce,
+                    *server_timestamp,
+                );
+                challenge_session
+                    .authenticate(Authentication::TokenChallengeResponse(Bytes::from(
+                        response.as_bytes().to_vec(),
+                    )))
+                    .await
+            }
+            _ => Err(crate::Error::InvalidCredentials),
+        }
+    }
+
+    /// Authenticates a [`User`](crate::admin::User) using a password. If
+    ///  successful, the returned instance will have the permissions from
+    ///  `identity`.
+    #[cfg(feature = "password-hashing")]
+    async fn authenticate_with_password<'name, User: Nameable<'name, u64> + Send>(
+        &self,
+        user: User,
+        password: SensitiveString,
+    ) -> Result<Self::Authenticated, crate::Error> {
+        self.authenticate(Authentication::password(user, password)?)
+            .await
+    }
 
     /// Assumes the `identity`. If successful, the returned instance will have
     /// the merged permissions of the current authentication session and the
@@ -3269,9 +3366,9 @@ pub struct Database {
     pub schema: SchemaName,
 }
 
-/// A plain-text password. This struct automatically overwrites the password
-/// with zeroes when dropped.
-#[derive(Clone, Serialize, Deserialize, Zeroize)]
+/// A string containing sensitive (private) data. This struct automatically
+/// overwrites its contents with zeroes when dropped.
+#[derive(Clone, Serialize, Deserialize, Zeroize, Eq, PartialEq)]
 #[zeroize(drop)]
 #[serde(transparent)]
 pub struct SensitiveString(pub String);
@@ -3290,12 +3387,115 @@ impl Deref for SensitiveString {
     }
 }
 
-/// User authentication methods.
+impl<'k> Key<'k> for SensitiveString {
+    fn from_ord_bytes(bytes: &'k [u8]) -> Result<Self, Self::Error> {
+        String::from_ord_bytes(bytes).map(Self)
+    }
+}
+
+impl<'k> KeyEncoding<'k, Self> for SensitiveString {
+    type Error = FromUtf8Error;
+
+    const LENGTH: Option<usize> = None;
+
+    fn as_ord_bytes(&'k self) -> Result<std::borrow::Cow<'k, [u8]>, Self::Error> {
+        self.0.as_ord_bytes()
+    }
+}
+
+/// A buffer containing sensitive (private) data. This struct automatically
+/// overwrites its contents with zeroes when dropped.
+#[derive(Clone, Serialize, Deserialize, Zeroize, Eq, PartialEq)]
+#[zeroize(drop)]
+#[serde(transparent)]
+pub struct SensitiveBytes(pub Bytes);
+
+impl std::fmt::Debug for SensitiveBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SensitiveBytes(...)")
+    }
+}
+
+impl Deref for SensitiveBytes {
+    type Target = Bytes;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'k> Key<'k> for SensitiveBytes {
+    fn from_ord_bytes(bytes: &'k [u8]) -> Result<Self, Self::Error> {
+        Bytes::from_ord_bytes(bytes).map(Self)
+    }
+}
+
+impl<'k> KeyEncoding<'k, Self> for SensitiveBytes {
+    type Error = Infallible;
+
+    const LENGTH: Option<usize> = None;
+
+    fn as_ord_bytes(&'k self) -> Result<std::borrow::Cow<'k, [u8]>, Self::Error> {
+        self.0.as_ord_bytes()
+    }
+}
+
+/// Authentication methods.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[must_use]
 pub enum Authentication {
-    /// Authenticate using a password.
+    /// Initialize token-based authentication.
+    Token {
+        /// The unique token id.
+        id: u64,
+        /// The current timestamp of the authenticating device. This must be
+        /// within 5 minutes of the server's time for token authentication to
+        /// succeed.
+        now: TimestampAsNanoseconds,
+        /// The hash of `now`, using the private token as key matter.
+        now_hash: Bytes,
+        /// The token challenge algorithm used to generate `now_hash`.
+        algorithm: TokenChallengeAlgorithm,
+    },
+    /// A response to the server's token authentication challenge.
+    TokenChallengeResponse(Bytes),
+    /// Authenticate a user with a password.
     #[cfg(feature = "password-hashing")]
-    Password(crate::connection::SensitiveString),
+    Password {
+        /// The username or the user id to authenticate as.
+        user: NamedReference<'static, u64>,
+        /// The password of the user.
+        password: SensitiveString,
+    },
+}
+
+impl Authentication {
+    /// Returns an authentication instance for this user and password.
+    #[cfg(feature = "password-hashing")]
+    pub fn password<'user, UsernameOrId: Nameable<'user, u64>>(
+        user: UsernameOrId,
+        password: SensitiveString,
+    ) -> Result<Self, crate::Error> {
+        Ok(Self::Password {
+            user: user.name()?.into_owned(),
+            password,
+        })
+    }
+
+    /// Returns a token authentication initialization instance for this token.
+    pub fn token(id: u64, token: &SensitiveBytes) -> Result<Self, crate::Error> {
+        let now = TimestampAsNanoseconds::now();
+        Ok(Self::Token {
+            id,
+            now,
+            now_hash: Bytes::from(
+                AuthenticationToken::compute_request_time_hash_blake3(now, token)
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            algorithm: TokenChallengeAlgorithm::Blake3,
+        })
+    }
 }
 
 #[doc(hidden)]
@@ -3394,9 +3594,71 @@ pub struct Session {
     /// The session's unique ID.
     pub id: Option<SessionId>,
     /// The authenticated identity, if any.
-    pub identity: Option<Arc<Identity>>,
+    pub authentication: SessionAuthentication,
     /// The effective permissions of the session.
     pub permissions: Permissions,
+}
+
+/// The authentication state of a [`Session`].
+#[derive(Hash, Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub enum SessionAuthentication {
+    /// The session is unauthenticated.
+    None,
+    /// The session is authenticated as an identity.
+    Identity(Arc<Identity>),
+    /// The session is pending authentication using a token.
+    TokenChallenge {
+        /// The id of the token being authenticated
+        id: u64,
+        /// The algorithm the server has chosen for the token challenge.
+        algorithm: TokenChallengeAlgorithm,
+        /// Random data generated by the server to be hashed during the
+        /// challenge.
+        nonce: [u8; 32],
+        /// The server timestamp that is used for authenticated extra data.
+        server_timestamp: TimestampAsNanoseconds,
+    },
+}
+
+impl Default for SessionAuthentication {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// A token challenge algorith designates with which algorthm to authenticate
+/// tokens.
+#[derive(Hash, Eq, PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum TokenChallengeAlgorithm {
+    /// Authenticate tokens using [`blake3`](https://crates.io/crates/blake3).
+    ///
+    /// The initial request requires a hash of [`TimestampAsNanoseconds::now()`]
+    /// to be performed using [`blake3::keyed_hash()`]. The key is derived using
+    /// [`blake3::derive_key()`] using a context formatted like this: `bonsaidb
+    /// {now} token-authentication`. The `now` value should be timestamp's
+    /// nanoseconds relative to [`BonsaiEpoch`](crate::key::time::BonsaiEpoch),
+    /// and the hash's contents should be the 8-byte big-endian representation
+    /// of the nanoseconds as an i64.
+    ///
+    /// The storage will verify that the timestamp is within a reasonable delta
+    /// of the server's current time, and it will verify the private token was
+    /// used to generate the hash sent. To prevent replay attacks and add
+    /// additional security, the server will return a new [`Session`] whose
+    /// authentication field is [`SessionAuthentication::TokenChallenge`].
+    ///
+    /// The connector must use the new connection to call `authenticate()` with
+    /// [`Authentication::TokenChallengeResponse`]. It is possible that the
+    /// server will elect a different challenge algorithm than the connector
+    /// chose when initially authenticating.
+    ///
+    /// To generate the challenge response for [`blake3`],
+    /// [`blake3::keyed_hash()`] is used to hash the `nonce`. The key is derived
+    /// using [`blake3::derive_key()`] using a context formatted like this:
+    /// `bonsaidb {server_timestamp} token-challenge`. The `server_timestamp`
+    /// value should be timestamp's nanoseconds relative to
+    /// [`BonsaiEpoch`](crate::key::time::BonsaiEpoch).
+    Blake3,
 }
 
 /// A unique session ID.
@@ -3426,19 +3688,29 @@ impl Session {
             .check(resource_name, action)
             .map_err(Error::from)
     }
+
+    /// Returns the identity that this session is authenticated as, if any.
+    #[must_use]
+    pub fn identity(&self) -> Option<&Identity> {
+        if let SessionAuthentication::Identity(identity) = &self.authentication {
+            Some(identity)
+        } else {
+            None
+        }
+    }
 }
 
 impl Eq for Session {}
 
 impl PartialEq for Session {
     fn eq(&self, other: &Self) -> bool {
-        self.identity == other.identity
+        self.authentication == other.authentication
     }
 }
 
 impl std::hash::Hash for Session {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.identity.hash(state);
+        self.authentication.hash(state);
     }
 }
 
@@ -3500,6 +3772,18 @@ pub enum IdentityReference<'name> {
 }
 
 impl<'name> IdentityReference<'name> {
+    /// Returns a reference to a [`User`]. This function accepts either the
+    /// user's unique id or their username.
+    pub fn user<User: Nameable<'name, u64>>(user: User) -> Result<Self, crate::Error> {
+        Ok(Self::User(user.name()?))
+    }
+
+    /// Returns a reference to a [`Role`]. This function accepts either the
+    /// role's unique id or the role's name.
+    pub fn role<Role: Nameable<'name, u64>>(role: Role) -> Result<Self, crate::Error> {
+        Ok(Self::Role(role.name()?))
+    }
+
     /// Converts this reference to an owned reference with a `'static` lifetime.
     #[must_use]
     pub fn into_owned(self) -> IdentityReference<'static> {
@@ -3508,4 +3792,37 @@ impl<'name> IdentityReference<'name> {
             IdentityReference::Role(role) => IdentityReference::Role(role.into_owned()),
         }
     }
+
+    /// Resolves this reference to the unique id.
+    pub fn resolve<C: Connection>(&self, admin: &C) -> Result<Option<IdentityId>, crate::Error> {
+        match self {
+            IdentityReference::User(name) => Ok(name.id::<User, _>(admin)?.map(IdentityId::User)),
+            IdentityReference::Role(name) => Ok(name.id::<Role, _>(admin)?.map(IdentityId::Role)),
+        }
+    }
+
+    /// Resolves this reference to the unique id.
+    pub async fn resolve_async<C: AsyncConnection>(
+        &self,
+        admin: &C,
+    ) -> Result<Option<IdentityId>, crate::Error> {
+        match self {
+            IdentityReference::User(name) => {
+                Ok(name.id_async::<User, _>(admin).await?.map(IdentityId::User))
+            }
+            IdentityReference::Role(name) => {
+                Ok(name.id_async::<Role, _>(admin).await?.map(IdentityId::Role))
+            }
+        }
+    }
+}
+
+/// An identity from the connected BonsaiDb instance.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum IdentityId {
+    /// A [`User`](crate::admin::User) id.
+    User(u64),
+    /// A [`Role`](crate::admin::Role) id.
+    Role(u64),
 }

--- a/crates/bonsaidb-core/src/connection/lowlevel.rs
+++ b/crates/bonsaidb-core/src/connection/lowlevel.rs
@@ -33,10 +33,7 @@ use crate::{
 ///
 /// This trait's methods are not designed for ergonomics. See
 /// [`Connection`](super::Connection) for a higher-level interface.
-pub trait LowLevelConnection: HasSession {
-    /// Returns the schema for the database.
-    fn schematic(&self) -> &Schematic;
-
+pub trait LowLevelConnection: HasSchema + HasSession {
     /// Inserts a newly created document into the connected [`schema::Schema`]
     /// for the [`Collection`](schema::Collection) `C`. If `id` is `None` a unique id will be
     /// generated. If an id is provided and a document already exists with that
@@ -626,10 +623,7 @@ pub trait LowLevelConnection: HasSession {
 /// This trait's methods are not designed for ergonomics. See
 /// [`AsyncConnection`](super::AsyncConnection) for a higher-level interface.
 #[async_trait]
-pub trait AsyncLowLevelConnection: HasSession + Send + Sync {
-    /// Returns the schema for the database.
-    fn schematic(&self) -> &Schematic;
-
+pub trait AsyncLowLevelConnection: HasSchema + HasSession + Send + Sync {
     /// Inserts a newly created document into the connected [`schema::Schema`]
     /// for the [`Collection`](schema::Collection) `C`. If `id` is `None` a unique id will be
     /// generated. If an id is provided and a document already exists with that
@@ -1244,4 +1238,10 @@ pub trait AsyncLowLevelConnection: HasSession + Send + Sync {
         key: Option<SerializedQueryKey>,
         access_policy: AccessPolicy,
     ) -> Result<u64, Error>;
+}
+
+/// Access to a connection's schema.
+pub trait HasSchema {
+    /// Returns the schema for the database.
+    fn schematic(&self) -> &Schematic;
 }

--- a/crates/bonsaidb-core/src/networking.rs
+++ b/crates/bonsaidb-core/src/networking.rs
@@ -147,14 +147,14 @@ impl Api for SetUserPassword {
 }
 
 /// Authenticate the current connection.
-#[cfg(feature = "password-hashing")]
+#[cfg(any(feature = "password-hashing", feature = "token-authentication"))]
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct Authenticate {
     /// The method of authentication.
     pub authentication: crate::connection::Authentication,
 }
 
-#[cfg(feature = "password-hashing")]
+#[cfg(any(feature = "password-hashing", feature = "token-authentication"))]
 impl Api for Authenticate {
     type Response = Session;
     type Error = crate::Error;

--- a/crates/bonsaidb-core/src/networking.rs
+++ b/crates/bonsaidb-core/src/networking.rs
@@ -146,12 +146,10 @@ impl Api for SetUserPassword {
     }
 }
 
-/// Authenticate as a user.
+/// Authenticate the current connection.
 #[cfg(feature = "password-hashing")]
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct Authenticate {
-    /// The username or id of the user.
-    pub user: NamedReference<'static, u64>,
     /// The method of authentication.
     pub authentication: crate::connection::Authentication,
 }

--- a/crates/bonsaidb-core/src/permissions/bonsai.rs
+++ b/crates/bonsaidb-core/src/permissions/bonsai.rs
@@ -2,6 +2,7 @@ use actionable::{Action, Identifier, ResourceName};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    connection::AuthenticationMethod,
     document::{DocumentId, KeyId},
     schema::{CollectionName, ViewName},
 };
@@ -147,16 +148,6 @@ pub enum ServerAction {
     /// Permits .
     /// Permits [`StorageConnection::add_role_to_user`](crate::connection::StorageConnection::add_role_to_user) and [`StorageConnection::remove_role_from_user`](crate::connection::StorageConnection::remove_role_from_user).
     ModifyUserRoles,
-}
-
-/// Methods for authentication.
-#[derive(Action, Serialize, Deserialize, Clone, Copy, Debug)]
-pub enum AuthenticationMethod {
-    /// Authenticate the user or role using an
-    /// [`AuthenticationToken`](crate::admin::AuthenticationToken).
-    Token,
-    /// Authenticate a user using password hashing (Argon2).
-    PasswordHash,
 }
 
 /// Actions that operate on a specific database.

--- a/crates/bonsaidb-core/src/permissions/bonsai.rs
+++ b/crates/bonsaidb-core/src/permissions/bonsai.rs
@@ -98,6 +98,14 @@ pub fn role_resource_name<'a>(role_id: u64) -> ResourceName<'a> {
     bonsaidb_resource_name().and("role").and(role_id)
 }
 
+/// Creates a resource name for `token_id`.
+#[must_use]
+pub fn authentication_token_resource_name<'a>(token_id: u64) -> ResourceName<'a> {
+    bonsaidb_resource_name()
+        .and("authentication-token")
+        .and(token_id)
+}
+
 /// Actions that can be permitted within BonsaiDb.
 #[derive(Action, Serialize, Deserialize, Clone, Copy, Debug)]
 pub enum BonsaiAction {
@@ -141,10 +149,13 @@ pub enum ServerAction {
     ModifyUserRoles,
 }
 
-/// Methods for user authentication.
+/// Methods for authentication.
 #[derive(Action, Serialize, Deserialize, Clone, Copy, Debug)]
 pub enum AuthenticationMethod {
-    /// Authenticate the user using password hashing (Argon2).
+    /// Authenticate the user or role using an
+    /// [`AuthenticationToken`](crate::admin::AuthenticationToken).
+    Token,
+    /// Authenticate a user using password hashing (Argon2).
     PasswordHash,
 }
 

--- a/crates/bonsaidb-core/src/schema/collection.rs
+++ b/crates/bonsaidb-core/src/schema/collection.rs
@@ -1457,6 +1457,19 @@ impl<'a, Id> Nameable<'a, Id> for NamedReference<'a, Id> {
     }
 }
 
+impl<'a, Id> Nameable<'a, Id> for &'a NamedReference<'a, Id>
+where
+    Id: Clone,
+{
+    fn name(self) -> Result<NamedReference<'a, Id>, crate::Error> {
+        Ok(match self {
+            NamedReference::Name(name) => NamedReference::Name(name.clone()),
+            NamedReference::Id(id) => NamedReference::Id(id.clone()),
+            NamedReference::Key(key) => NamedReference::Key(key.clone()),
+        })
+    }
+}
+
 impl<'a, Id> Nameable<'a, Id> for &'a str {
     fn name(self) -> Result<NamedReference<'a, Id>, crate::Error> {
         Ok(NamedReference::from(self))

--- a/crates/bonsaidb-core/src/test_util.rs
+++ b/crates/bonsaidb-core/src/test_util.rs
@@ -17,9 +17,10 @@ use serde::{Deserialize, Serialize};
 use transmog_pot::Pot;
 
 use crate::{
-    admin::{PermissionGroup, Role, User},
+    admin::{AuthenticationToken, PermissionGroup, Role, User},
     connection::{
-        AccessPolicy, AsyncConnection, AsyncStorageConnection, Connection, StorageConnection,
+        AccessPolicy, AsyncConnection, AsyncStorageConnection, Connection, HasSession, Identity,
+        IdentityReference, Session, StorageConnection,
     },
     document::{
         BorrowedDocument, CollectionDocument, CollectionHeader, DocumentId, Emit, Header, KeyId,
@@ -462,6 +463,7 @@ pub enum HarnessTest {
     NamedCollection,
     PubSubSimple,
     UserManagement,
+    TokenAuthentication,
     PubSubMultipleSubscribers,
     PubSubDropAndSend,
     PubSubUnsubscribe,
@@ -706,6 +708,26 @@ macro_rules! define_async_connection_test_suite {
             }
 
             #[tokio::test]
+            async fn token_authentication() -> anyhow::Result<()> {
+                use $crate::connection::AsyncStorageConnection;
+                let harness =
+                    $harness::new($crate::test_util::HarnessTest::TokenAuthentication).await?;
+                let _db = harness.connect().await?;
+                let server = harness.server();
+                let admin = server
+                    .database::<$crate::admin::Admin>($crate::admin::ADMIN_DATABASE_NAME)
+                    .await?;
+
+                $crate::test_util::token_authentication_tests(
+                    &admin,
+                    server,
+                    $harness::server_name(),
+                )
+                .await?;
+                harness.shutdown().await
+            }
+
+            #[tokio::test]
             async fn compaction() -> anyhow::Result<()> {
                 let harness = $harness::new($crate::test_util::HarnessTest::Compact).await?;
                 let db = harness.connect().await?;
@@ -907,6 +929,23 @@ macro_rules! define_blocking_connection_test_suite {
                     server.database::<$crate::admin::Admin>($crate::admin::ADMIN_DATABASE_NAME)?;
 
                 $crate::test_util::blocking_user_management_tests(
+                    &admin,
+                    server,
+                    $harness::server_name(),
+                )?;
+                harness.shutdown()
+            }
+
+            #[test]
+            fn token_authentication() -> anyhow::Result<()> {
+                use $crate::connection::StorageConnection;
+                let harness = $harness::new($crate::test_util::HarnessTest::TokenAuthentication)?;
+                let _db = harness.connect()?;
+                let server = harness.server();
+                let admin =
+                    server.database::<$crate::admin::Admin>($crate::admin::ADMIN_DATABASE_NAME)?;
+
+                $crate::test_util::blocking_token_authentication_tests(
                     &admin,
                     server,
                     $harness::server_name(),
@@ -2658,6 +2697,73 @@ pub fn blocking_user_management_tests<C: Connection, S: StorageConnection>(
     // Test if user is removed.
 
     assert!(User::get(&user_id, admin).unwrap().is_none());
+
+    Ok(())
+}
+
+pub async fn token_authentication_tests<C: AsyncConnection, S: AsyncStorageConnection>(
+    admin: &C,
+    server: &S,
+    server_name: &str,
+) -> anyhow::Result<()> {
+    let username = format!("token-authentication-tests-{}", server_name);
+    let user_id = server.create_user(&username).await?;
+    let user_token =
+        AuthenticationToken::create_async(IdentityReference::user(&username)?, admin).await?;
+
+    let as_user = server
+        .authenticate_with_token(user_token.header.id, &user_token.contents.token)
+        .await?;
+    let identity = as_user.session().and_then(Session::identity);
+    if let Some(Identity::User { id, .. }) = identity {
+        assert_eq!(*id, user_id);
+    }
+
+    let role = Role::named(format!("token-role-{}", server_name))
+        .push_into_async(admin)
+        .await
+        .unwrap();
+    let role_token =
+        AuthenticationToken::create_async(IdentityReference::role(role.header.id)?, admin).await?;
+
+    let as_role = server
+        .authenticate_with_token(role_token.header.id, &role_token.contents.token)
+        .await?;
+    let identity = as_role.session().and_then(Session::identity);
+    if let Some(Identity::Role { id, .. }) = identity {
+        assert_eq!(*id, role.header.id);
+    }
+
+    Ok(())
+}
+
+pub fn blocking_token_authentication_tests<C: Connection, S: StorageConnection>(
+    admin: &C,
+    server: &S,
+    server_name: &str,
+) -> anyhow::Result<()> {
+    let username = format!("blocking-token-authentication-tests-{}", server_name);
+    let user_id = server.create_user(&username)?;
+    let user_token = AuthenticationToken::create(&IdentityReference::user(&username)?, admin)?;
+
+    let as_user =
+        server.authenticate_with_token(user_token.header.id, &user_token.contents.token)?;
+    let identity = as_user.session().and_then(Session::identity);
+    if let Some(Identity::User { id, .. }) = identity {
+        assert_eq!(*id, user_id);
+    }
+
+    let role = Role::named(format!("token-role-{}", server_name))
+        .push_into(admin)
+        .unwrap();
+    let role_token = AuthenticationToken::create(&IdentityReference::role(role.header.id)?, admin)?;
+
+    let as_role =
+        server.authenticate_with_token(role_token.header.id, &role_token.contents.token)?;
+    let identity = as_role.session().and_then(Session::identity);
+    if let Some(Identity::Role { id, .. }) = identity {
+        assert_eq!(*id, role.header.id);
+    }
 
     Ok(())
 }

--- a/crates/bonsaidb-core/src/test_util.rs
+++ b/crates/bonsaidb-core/src/test_util.rs
@@ -16,11 +16,15 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use transmog_pot::Pot;
 
+#[cfg(feature = "token-authentication")]
 use crate::{
-    admin::{AuthenticationToken, PermissionGroup, Role, User},
+    admin::AuthenticationToken,
+    connection::{HasSession, Identity, IdentityReference, Session},
+};
+use crate::{
+    admin::{PermissionGroup, Role, User},
     connection::{
-        AccessPolicy, AsyncConnection, AsyncStorageConnection, Connection, HasSession, Identity,
-        IdentityReference, Session, StorageConnection,
+        AccessPolicy, AsyncConnection, AsyncStorageConnection, Connection, StorageConnection,
     },
     document::{
         BorrowedDocument, CollectionDocument, CollectionHeader, DocumentId, Emit, Header, KeyId,
@@ -708,6 +712,7 @@ macro_rules! define_async_connection_test_suite {
             }
 
             #[tokio::test]
+            #[cfg(feature = "token-authentication")]
             async fn token_authentication() -> anyhow::Result<()> {
                 use $crate::connection::AsyncStorageConnection;
                 let harness =
@@ -937,6 +942,7 @@ macro_rules! define_blocking_connection_test_suite {
             }
 
             #[test]
+            #[cfg(feature = "token-authentication")]
             fn token_authentication() -> anyhow::Result<()> {
                 use $crate::connection::StorageConnection;
                 let harness = $harness::new($crate::test_util::HarnessTest::TokenAuthentication)?;
@@ -2701,6 +2707,7 @@ pub fn blocking_user_management_tests<C: Connection, S: StorageConnection>(
     Ok(())
 }
 
+#[cfg(feature = "token-authentication")]
 pub async fn token_authentication_tests<C: AsyncConnection, S: AsyncStorageConnection>(
     admin: &C,
     server: &S,
@@ -2737,6 +2744,7 @@ pub async fn token_authentication_tests<C: AsyncConnection, S: AsyncStorageConne
     Ok(())
 }
 
+#[cfg(feature = "token-authentication")]
 pub fn blocking_token_authentication_tests<C: Connection, S: StorageConnection>(
     admin: &C,
     server: &S,

--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -32,7 +32,6 @@ encryption = [
     "hpke",
     "zeroize",
     "region",
-    "blake3",
     "chacha20poly1305",
 ]
 compression = ["lz4_flex"]
@@ -68,7 +67,6 @@ futures = { version = "0.3.19", optional = true }
 chacha20poly1305 = { version = "0.9", optional = true }
 zeroize = { version = "1", optional = true }
 region = { version = "3", optional = true }
-blake3 = { version = "1", optional = true }
 hpke = { version = "0.8", default-features = false, features = [
     "p256",
     "serde_impls",

--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -41,6 +41,7 @@ password-hashing = [
     "once_cell",
     "bonsaidb-core/password-hashing",
 ]
+token-authentication = ["bonsaidb-core/token-authentication"]
 included-from-omnibus = []
 async = ["tokio", "async-trait", "futures"]
 

--- a/crates/bonsaidb-local/README.md
+++ b/crates/bonsaidb-local/README.md
@@ -24,6 +24,8 @@ By default, the `full` feature is enabled.
 - `multiuser`: Enables multi-user support.
 - `password-hashing`: Enables the ability to use password authentication using
   Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ## Open-source Licenses
 

--- a/crates/bonsaidb-local/local-feature-flags.md
+++ b/crates/bonsaidb-local/local-feature-flags.md
@@ -11,3 +11,5 @@ By default, the `full` feature is enabled.
 - `multiuser`: Enables multi-user support.
 - `password-hashing`: Enables the ability to use password authentication using
   Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.

--- a/crates/bonsaidb-local/src/async.rs
+++ b/crates/bonsaidb-local/src/async.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-#[cfg(feature = "password-hashing")]
-use bonsaidb_core::connection::Authentication;
 use bonsaidb_core::{
     connection::{
         self, AccessPolicy, AsyncConnection, AsyncLowLevelConnection, AsyncStorageConnection,
@@ -471,7 +469,7 @@ impl AsyncStorageConnection for AsyncStorage {
     #[cfg(any(feature = "token-authentication", feature = "password-hashing"))]
     async fn authenticate(
         &self,
-        authentication: Authentication,
+        authentication: bonsaidb_core::connection::Authentication,
     ) -> Result<Self, bonsaidb_core::Error> {
         let task_self = self.clone();
         self.runtime

--- a/crates/bonsaidb-local/src/async.rs
+++ b/crates/bonsaidb-local/src/async.rs
@@ -6,8 +6,8 @@ use bonsaidb_core::connection::Authentication;
 use bonsaidb_core::{
     connection::{
         self, AccessPolicy, AsyncConnection, AsyncLowLevelConnection, AsyncStorageConnection,
-        Connection, HasSession, IdentityReference, LowLevelConnection, Range, SerializedQueryKey,
-        Session, Sort, StorageConnection,
+        Connection, HasSchema, HasSession, IdentityReference, LowLevelConnection, Range,
+        SerializedQueryKey, Session, Sort, StorageConnection,
     },
     document::{DocumentId, Header, OwnedDocument},
     keyvalue::{AsyncKeyValue, KeyOperation, KeyValue, Output},
@@ -468,19 +468,16 @@ impl AsyncStorageConnection for AsyncStorage {
             .map_err(Error::from)?
     }
 
-    #[cfg(feature = "password-hashing")]
-    async fn authenticate<'user, U: Nameable<'user, u64> + Send + Sync>(
+    async fn authenticate(
         &self,
-        user: U,
         authentication: Authentication,
     ) -> Result<Self, bonsaidb_core::Error> {
         let task_self = self.clone();
-        let user = user.name()?.into_owned();
         self.runtime
             .spawn_blocking(move || {
                 task_self
                     .storage
-                    .authenticate(user, authentication)
+                    .authenticate(authentication)
                     .map(Storage::into_async)
             })
             .await
@@ -713,12 +710,14 @@ impl AsyncSubscriber for Subscriber {
     }
 }
 
-#[async_trait]
-impl AsyncLowLevelConnection for AsyncDatabase {
+impl HasSchema for AsyncDatabase {
     fn schematic(&self) -> &Schematic {
         self.database.schematic()
     }
+}
 
+#[async_trait]
+impl AsyncLowLevelConnection for AsyncDatabase {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(transaction)))]
     async fn apply_transaction(
         &self,

--- a/crates/bonsaidb-local/src/async.rs
+++ b/crates/bonsaidb-local/src/async.rs
@@ -468,6 +468,7 @@ impl AsyncStorageConnection for AsyncStorage {
             .map_err(Error::from)?
     }
 
+    #[cfg(any(feature = "token-authentication", feature = "password-hashing"))]
     async fn authenticate(
         &self,
         authentication: Authentication,

--- a/crates/bonsaidb-local/src/storage.rs
+++ b/crates/bonsaidb-local/src/storage.rs
@@ -730,7 +730,7 @@ impl StorageInstance {
             not(feature = "token-authentication"),
             not(feature = "password-hashing")
         ),
-        allow(unused_variables)
+        allow(unused_variables, clippy::needless_pass_by_value)
     )]
     fn authenticate_inner(
         &self,

--- a/crates/bonsaidb-local/src/storage/token_authentication.rs
+++ b/crates/bonsaidb-local/src/storage/token_authentication.rs
@@ -1,0 +1,118 @@
+use std::sync::Arc;
+
+use bonsaidb_core::{
+    admin::{AuthenticationToken, Role, User},
+    connection::{IdentityId, Session, SessionAuthentication, SessionId, TokenChallengeAlgorithm},
+    key::time::TimestampAsNanoseconds,
+    permissions::Permissions,
+    schema::SerializedCollection,
+};
+use parking_lot::Mutex;
+use rand::{thread_rng, Rng};
+
+use crate::{storage::AuthenticatedSession, Database, Storage};
+
+impl super::StorageInstance {
+    pub(super) fn begin_token_authentication(
+        &self,
+        id: u64,
+        request_time: TimestampAsNanoseconds,
+        request_time_check: &[u8],
+        algorithm: TokenChallengeAlgorithm,
+        admin: &Database,
+    ) -> Result<Storage, bonsaidb_core::Error> {
+        // TODO alow configuration of timestamp sensitivity. 5 minutes chosen based on Kerberos and
+        if request_time
+            .duration_between(&TimestampAsNanoseconds::now())?
+            .as_secs()
+            > 300
+        {
+            return Err(bonsaidb_core::Error::InvalidCredentials); // TODO better error
+        }
+        let token = AuthenticationToken::get(&id, admin)?
+            .ok_or(bonsaidb_core::Error::InvalidCredentials)?;
+        AuthenticationToken::check_request_time(
+            request_time,
+            request_time_check,
+            algorithm,
+            &token.contents.token,
+        )?;
+
+        // Token authentication creates a temporary session for the token
+        // challenge. The process of finishing token authentication will remove
+        // the session.
+
+        let mut sessions = self.data.sessions.write();
+        sessions.last_session_id += 1;
+        let session_id = SessionId(sessions.last_session_id);
+        let nonce = thread_rng().gen::<[u8; 32]>();
+        let session = Session {
+            id: Some(session_id),
+            authentication: SessionAuthentication::TokenChallenge {
+                id,
+                algorithm: TokenChallengeAlgorithm::Blake3,
+                nonce,
+                server_timestamp: TimestampAsNanoseconds::now(),
+            },
+            permissions: Permissions::default(), /* This session will have no permissions until it finishes token authentication */
+        };
+        let authentication = Arc::new(AuthenticatedSession {
+            storage: Arc::downgrade(&self.data),
+            session: Mutex::new(session.clone()),
+        });
+        sessions.sessions.insert(session_id, authentication.clone());
+
+        Ok(Storage {
+            instance: self.clone(),
+            authentication: Some(authentication),
+            effective_session: Some(Arc::new(session)),
+        })
+    }
+
+    pub(super) fn finish_token_authentication(
+        &self,
+        session_id: SessionId,
+        hash: &[u8],
+        admin: &Database,
+    ) -> Result<Storage, bonsaidb_core::Error> {
+        // Remove the temporary session so that it can't be used multiple times.
+        let session = {
+            let mut sessions = self.data.sessions.write();
+            sessions
+                .sessions
+                .remove(&session_id)
+                .ok_or(bonsaidb_core::Error::InvalidCredentials)?
+        };
+        let session = session.session.lock();
+        match &session.authentication {
+            SessionAuthentication::TokenChallenge {
+                id,
+                algorithm,
+                nonce,
+                server_timestamp,
+            } => {
+                let token = AuthenticationToken::get(id, admin)?
+                    .ok_or(bonsaidb_core::Error::InvalidCredentials)?;
+                token
+                    .contents
+                    .validate_challenge(*algorithm, *server_timestamp, nonce, hash)?;
+                match token.contents.identity {
+                    IdentityId::User(id) => {
+                        let user = User::get(&id, admin)?
+                            .ok_or(bonsaidb_core::Error::InvalidCredentials)?;
+                        self.assume_user(user, admin)
+                    }
+                    IdentityId::Role(id) => {
+                        let role = Role::get(&id, admin)?
+                            .ok_or(bonsaidb_core::Error::InvalidCredentials)?;
+                        self.assume_role(role, admin)
+                    }
+                    _ => Err(bonsaidb_core::Error::InvalidCredentials),
+                }
+            }
+            SessionAuthentication::None | SessionAuthentication::Identity(_) => {
+                Err(bonsaidb_core::Error::InvalidCredentials)
+            }
+        }
+    }
+}

--- a/crates/bonsaidb-server/Cargo.toml
+++ b/crates/bonsaidb-server/Cargo.toml
@@ -38,6 +38,10 @@ password-hashing = [
     "bonsaidb-local/password-hashing",
     "bonsaidb-core/password-hashing",
 ]
+token-authentication = [
+    "bonsaidb-core/token-authentication",
+    "bonsaidb-local/token-authentication",
+]
 compression = ["bonsaidb-local/compression"]
 
 included-from-omnibus = []

--- a/crates/bonsaidb-server/README.md
+++ b/crates/bonsaidb-server/README.md
@@ -36,6 +36,8 @@ By default, the `full` feature is enabled.
 - `websockets`: Enables `WebSocket` support.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ## Open-source Licenses
 

--- a/crates/bonsaidb-server/server-feature-flags.md
+++ b/crates/bonsaidb-server/server-feature-flags.md
@@ -12,3 +12,5 @@ By default, the `full` feature is enabled.
 - `websockets`: Enables `WebSocket` support.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.

--- a/crates/bonsaidb-server/src/backend.rs
+++ b/crates/bonsaidb-server/src/backend.rs
@@ -75,7 +75,7 @@ pub trait Backend: Debug + Send + Sync + Sized + 'static {
         log::info!(
             "{:?} client authenticated as user: {:?}",
             client.transport(),
-            session.identity
+            session.authentication
         );
         Ok(())
     }

--- a/crates/bonsaidb-server/src/dispatch.rs
+++ b/crates/bonsaidb-server/src/dispatch.rs
@@ -196,7 +196,7 @@ impl<B: Backend> Handler<B, Authenticate> for ServerDispatcher {
     ) -> HandlerResult<Authenticate> {
         let authenticated = session
             .as_client
-            .authenticate(command.user, command.authentication)
+            .authenticate(command.authentication)
             .await?;
         let new_session = authenticated.session().cloned().unwrap();
 

--- a/crates/bonsaidb-server/src/server.rs
+++ b/crates/bonsaidb-server/src/server.rs
@@ -875,13 +875,11 @@ impl<B: Backend> AsyncStorageConnection for CustomServer<B> {
         self.storage.set_user_password(user, password).await
     }
 
-    #[cfg(feature = "password-hashing")]
-    async fn authenticate<'user, U: Nameable<'user, u64> + Send + Sync>(
+    async fn authenticate(
         &self,
-        user: U,
         authentication: Authentication,
     ) -> Result<Self::Authenticated, bonsaidb_core::Error> {
-        let storage = self.storage.authenticate(user, authentication).await?;
+        let storage = self.storage.authenticate(authentication).await?;
         Ok(Self {
             data: self.data.clone(),
             storage,

--- a/crates/bonsaidb-server/src/server.rs
+++ b/crates/bonsaidb-server/src/server.rs
@@ -875,6 +875,7 @@ impl<B: Backend> AsyncStorageConnection for CustomServer<B> {
         self.storage.set_user_password(user, password).await
     }
 
+    #[cfg(any(feature = "token-authentication", feature = "password-hashing"))]
     async fn authenticate(
         &self,
         authentication: Authentication,

--- a/crates/bonsaidb-server/src/server.rs
+++ b/crates/bonsaidb-server/src/server.rs
@@ -13,8 +13,6 @@ use std::{
 
 use async_lock::{Mutex, RwLock};
 use async_trait::async_trait;
-#[cfg(feature = "password-hashing")]
-use bonsaidb_core::connection::Authentication;
 use bonsaidb_core::{
     admin::{Admin, ADMIN_DATABASE_NAME},
     api,
@@ -878,7 +876,7 @@ impl<B: Backend> AsyncStorageConnection for CustomServer<B> {
     #[cfg(any(feature = "token-authentication", feature = "password-hashing"))]
     async fn authenticate(
         &self,
-        authentication: Authentication,
+        authentication: bonsaidb_core::connection::Authentication,
     ) -> Result<Self::Authenticated, bonsaidb_core::Error> {
         let storage = self.storage.authenticate(authentication).await?;
         Ok(Self {

--- a/crates/bonsaidb-server/src/server/database.rs
+++ b/crates/bonsaidb-server/src/server/database.rs
@@ -3,7 +3,8 @@ use std::ops::Deref;
 use async_trait::async_trait;
 use bonsaidb_core::{
     connection::{
-        AccessPolicy, AsyncLowLevelConnection, HasSession, Range, SerializedQueryKey, Sort,
+        AccessPolicy, AsyncLowLevelConnection, HasSchema, HasSession, Range, SerializedQueryKey,
+        Sort,
     },
     document::{DocumentId, Header, OwnedDocument},
     keyvalue::AsyncKeyValue,
@@ -140,10 +141,6 @@ impl<B: Backend> AsyncKeyValue for ServerDatabase<B> {
 
 #[async_trait]
 impl<B: Backend> AsyncLowLevelConnection for ServerDatabase<B> {
-    fn schematic(&self) -> &Schematic {
-        self.db.schematic()
-    }
-
     async fn get_from_collection(
         &self,
         id: DocumentId,
@@ -259,5 +256,11 @@ impl<B: Backend> AsyncLowLevelConnection for ServerDatabase<B> {
         transaction: Transaction,
     ) -> Result<Vec<OperationResult>, bonsaidb_core::Error> {
         self.db.apply_transaction(transaction).await
+    }
+}
+
+impl<B: Backend> HasSchema for ServerDatabase<B> {
+    fn schematic(&self) -> &Schematic {
+        self.db.schematic()
     }
 }

--- a/crates/bonsaidb/Cargo.toml
+++ b/crates/bonsaidb/Cargo.toml
@@ -70,6 +70,13 @@ password-hashing = [
     "bonsaidb-client?/password-hashing",
 ]
 
+token-authentication = [
+    "bonsaidb-core/token-authentication",
+    "bonsaidb-local?/token-authentication",
+    "bonsaidb-server?/token-authentication",
+    "bonsaidb-client?/token-authentication",
+]
+
 compression = ["bonsaidb-local?/compression", "bonsaidb-server?/compression"]
 
 async = ["bonsaidb-local?/async"]

--- a/crates/bonsaidb/crate-docs.md
+++ b/crates/bonsaidb/crate-docs.md
@@ -79,7 +79,7 @@ Shape { sides: 3 }.push_into(&db)?;
 And query data using the Map-Reduce-powered view:
 
 ```rust,ignore
-let triangles = db.view::<ShapesByNumberOfSides>().with_key(3).query()?;
+let triangles = db.view::<ShapesByNumberOfSides>().with_key(&3).query()?;
 println!("Number of triangles: {}", triangles.len());
 ```
 
@@ -113,6 +113,8 @@ bonsaidb = { version = "*", features = "full" }
 - `cli`: Enables the `bonsaidb` executable.
 - `password-hashing`: Enables the ability to use password authentication using
   Argon2 via `AnyConnection`.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 All other feature flags, listed below, affect each crate individually, but can
 be safely combined.
@@ -137,6 +139,8 @@ All Cargo features that affect local databases:
 - `instrument`: Enables instrumenting with `tracing`.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ### BonsaiDb server
 
@@ -160,6 +164,8 @@ All Cargo features that affect networked servers:
 - `websockets`: Enables `WebSocket` support.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ### Client for accessing a BonsaiDb server
 
@@ -178,6 +184,8 @@ All Cargo features that affect networked clients:
 - `websockets`: Enables `WebSocket` support for `bonsaidb-client`.
 - `password-hashing`: Enables the ability to use password authentication
   using Argon2.
+- `token-authentication`: Enables the ability to authenticate using
+  authentication tokens, which are similar to API keys.
 
 ## Developing BonsaiDb
 

--- a/crates/bonsaidb/src/any_connection.rs
+++ b/crates/bonsaidb/src/any_connection.rs
@@ -1,6 +1,4 @@
 use bonsaidb_client::{Client, RemoteDatabase};
-#[cfg(feature = "password-hashing")]
-use bonsaidb_core::connection::Authentication;
 use bonsaidb_core::{
     async_trait::async_trait,
     connection::{
@@ -133,7 +131,7 @@ impl<B: Backend> AsyncStorageConnection for AnyServerConnection<B> {
     #[cfg(any(feature = "token-authentication", feature = "password-hashing"))]
     async fn authenticate(
         &self,
-        authentication: Authentication,
+        authentication: bonsaidb_core::connection::Authentication,
     ) -> Result<Self::Authenticated, bonsaidb_core::Error> {
         match self {
             Self::Local(server) => server.authenticate(authentication).await.map(Self::Local),

--- a/crates/bonsaidb/src/any_connection.rs
+++ b/crates/bonsaidb/src/any_connection.rs
@@ -130,6 +130,7 @@ impl<B: Backend> AsyncStorageConnection for AnyServerConnection<B> {
         }
     }
 
+    #[cfg(any(feature = "token-authentication", feature = "password-hashing"))]
     async fn authenticate(
         &self,
         authentication: Authentication,

--- a/crates/bonsaidb/tests/core-suite.rs
+++ b/crates/bonsaidb/tests/core-suite.rs
@@ -21,10 +21,7 @@ use bonsaidb::{
         DefaultPermissions, Server, ServerConfiguration,
     },
 };
-use bonsaidb_core::{
-    connection::{Authentication, SensitiveString},
-    permissions::bonsai::AuthenticationMethod,
-};
+use bonsaidb_core::connection::{Authentication, AuthenticationMethod, SensitiveString};
 use once_cell::sync::Lazy;
 use rand::{distributions::Alphanumeric, Rng};
 use tokio::sync::Mutex;

--- a/crates/bonsaidb/tests/core-suite.rs
+++ b/crates/bonsaidb/tests/core-suite.rs
@@ -371,7 +371,7 @@ async fn assume_permissions(
     };
 
     connection
-        .authenticate(&username, Authentication::Password(password))
+        .authenticate(Authentication::password(username, password)?)
         .await
         .unwrap();
 
@@ -421,10 +421,10 @@ async fn authenticated_permissions_test() -> anyhow::Result<()> {
     }
 
     let authenticated_client = client
-        .authenticate(
+        .authenticate(Authentication::password(
             "ecton",
-            Authentication::Password(SensitiveString(String::from("hunter2"))),
-        )
+            SensitiveString(String::from("hunter2")),
+        )?)
         .await
         .unwrap();
     authenticated_client

--- a/examples/basic-server/examples/custom-api.rs
+++ b/examples/basic-server/examples/custom-api.rs
@@ -10,10 +10,12 @@ use bonsaidb::{
         actionable::Permissions,
         api::{Api, Infallible},
         async_trait::async_trait,
-        connection::{AsyncStorageConnection, Authentication, SensitiveString},
+        connection::{
+            AsyncStorageConnection, Authentication, AuthenticationMethod, SensitiveString,
+        },
         keyvalue::AsyncKeyValue,
         permissions::{
-            bonsai::{AuthenticationMethod, BonsaiAction, ServerAction},
+            bonsai::{BonsaiAction, ServerAction},
             Action, Identifier, Statement,
         },
         schema::{ApiName, Qualified},

--- a/examples/basic-server/examples/custom-api.rs
+++ b/examples/basic-server/examples/custom-api.rs
@@ -235,10 +235,10 @@ async fn invoke_apis(client: Client, client_name: &str) -> Result<(), bonsaidb::
 
     // Now, let's authenticate and try calling the APIs that previously were denied permissions
     let authenticated_client = client
-        .authenticate(
+        .authenticate(Authentication::password(
             "test-user",
-            Authentication::Password(SensitiveString(String::from("hunter2"))),
-        )
+            SensitiveString(String::from("hunter2")),
+        )?)
         .await
         .unwrap();
     assert!(matches!(

--- a/examples/basic-server/examples/users.rs
+++ b/examples/basic-server/examples/users.rs
@@ -188,10 +188,10 @@ async fn main() -> anyhow::Result<()> {
 
         // Now, log in and try again.
         let authenticated_client = client
-            .authenticate(
+            .authenticate(Authentication::password(
                 "ecton",
-                Authentication::Password(SensitiveString(String::from("hunter2"))),
-            )
+                SensitiveString(String::from("hunter2")),
+            )?)
             .await?;
 
         let db = authenticated_client

--- a/examples/basic-server/examples/users.rs
+++ b/examples/basic-server/examples/users.rs
@@ -6,11 +6,11 @@ use bonsaidb::{
     client::{url::Url, Client},
     core::{
         admin::{PermissionGroup, Role},
-        connection::{AsyncStorageConnection, Authentication, SensitiveString},
+        connection::{
+            AsyncStorageConnection, Authentication, AuthenticationMethod, SensitiveString,
+        },
         permissions::{
-            bonsai::{
-                AuthenticationMethod, BonsaiAction, DatabaseAction, DocumentAction, ServerAction,
-            },
+            bonsai::{BonsaiAction, DatabaseAction, DocumentAction, ServerAction},
             Permissions, Statement,
         },
         schema::{InsertError, SerializedCollection},

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -127,6 +127,10 @@ fn all_tests() -> &'static [TestSuite] {
             toolchain: "stable",
         },
         TestSuite {
+            cargo_args: "--package bonsaidb-local --no-default-features --features token-authentication",
+            toolchain: "stable",
+        },
+        TestSuite {
             cargo_args: "--package bonsaidb-local --no-default-features --features encryption,compression",
             toolchain: "stable",
         },
@@ -136,6 +140,10 @@ fn all_tests() -> &'static [TestSuite] {
         },
         TestSuite {
             cargo_args: "--package bonsaidb-server --no-default-features --features password-hashing",
+            toolchain: "stable",
+        },
+        TestSuite {
+            cargo_args: "--package bonsaidb-server --no-default-features --features token-authentication",
             toolchain: "stable",
         },
         TestSuite {
@@ -160,6 +168,10 @@ fn all_tests() -> &'static [TestSuite] {
         },
         TestSuite {
             cargo_args: "--package bonsaidb --no-default-features --features server,client,test-util",
+            toolchain: "stable",
+        },
+        TestSuite {
+            cargo_args: "--package bonsaidb --no-default-features --features server,client,test-util,token-authentication,websockets",
             toolchain: "stable",
         },
         TestSuite {


### PR DESCRIPTION
While working on [Dossier](https://github.com/khonsulabs/dossier), I wanted to allow generating tokens to use in continuous integration that allow authenticating using the BonsaiDb built-in Cli interface.

This pull request looks to address the ability to assume a user or role's identity using a token created on the server.

The approach is described in the documentation on `TokenChallengeAlgorithm::Blake3`, and the hash computation and actual hash calls are constrained to `authentication_token.rs`.

- [x] Make token authentication an optional feature.