### PR TITLE
hpke & p256 crates update

### DIFF
--- a/crates/bonsaidb-local/Cargo.toml
+++ b/crates/bonsaidb-local/Cargo.toml
@@ -68,11 +68,11 @@ chacha20poly1305 = { version = "0.9", optional = true }
 zeroize = { version = "1", optional = true }
 region = { version = "3", optional = true }
 blake3 = { version = "1", optional = true }
-hpke = { version = "0.8", default-features = false, features = [
+hpke = { version = "0.10", default-features = false, features = [
     "p256",
     "serde_impls",
 ], optional = true }
-p256 = "0.9.0"
+p256 = "0.11.0"
 tracing = { version = "0.1", optional = true, default-features = false, features = [
     "attributes",
 ] }


### PR DESCRIPTION
I am using `bonsaidb` in a project which also uses the `webrtc` crate resulting in a conflict with bonsaidb due to a dependency on a newer version of p256.

This patch updates `p256` and it's dependent crate `hpke` to their latest stable versions.