### PR TITLE
Session deauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer blocked until complete.
 - `CustomServer::listen_for_shutdown()` now listens for
   `CustomServer::shutdown()` in addition to operating system signals.
+- `Client` will no longer return a `Session` from a previous connection. Because
+  the `Client` automatically reconnects, the `Session`s are no longer
+  authenticated.
+- `CustomServer::shutdown` now fully shuts down the server by forcefully
+  disconnecting clients after the optional grace period has elapsed.
+  Additionally, QUIC-connected workers are sent the proper disconnection
+  notification.
 
 ## v0.4.1
 

--- a/crates/bonsaidb-client/src/client/remote_database.rs
+++ b/crates/bonsaidb-client/src/client/remote_database.rs
@@ -58,7 +58,7 @@ impl RemoteDatabase {
 
 impl HasSession for RemoteDatabase {
     fn session(&self) -> Option<&Session> {
-        Some(&self.session)
+        self.client.session()
     }
 }
 

--- a/crates/bonsaidb-core/src/test_util.rs
+++ b/crates/bonsaidb-core/src/test_util.rs
@@ -348,6 +348,7 @@ impl NamedCollection for Unique {
     type ByNameView = UniqueValue;
 }
 
+#[derive(Debug)]
 pub struct TestDirectory(pub PathBuf);
 
 impl TestDirectory {

--- a/crates/bonsaidb-macros/src/lib.rs
+++ b/crates/bonsaidb-macros/src/lib.rs
@@ -63,7 +63,7 @@ fn core_path() -> Path {
     invalid_field = r#"Only `authority = "some-authority"`, `name = "some-name"`, `views = [SomeView, AnotherView]`, `primary_key = u64`, `natural_id = |contents: &Self| Some(contents.id)`, serialization = SerializationFormat` and `core = bonsaidb::core` are supported attributes"#
 )]
 struct CollectionAttribute {
-    authority: Option<String>,
+    authority: Option<Expr>,
     #[attribute(
         missing = r#"You need to specify the collection name via `#[collection(name = "name")]`"#
     )]
@@ -318,7 +318,7 @@ pub fn view_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 struct SchemaAttribute {
     #[attribute(missing = r#"You need to specify the schema name via `#[schema(name = "name")]`"#)]
     name: String,
-    authority: Option<String>,
+    authority: Option<Expr>,
     #[attribute(default)]
     #[attribute(
         expected = r#"Specify the `collections` like so: `collections = [SomeCollection, AnotherCollection]`"#
@@ -672,7 +672,7 @@ pub fn key_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 struct ApiAttribute {
     #[attribute(missing = r#"You need to specify the api name via `#[api(name = "name")]`"#)]
     name: String,
-    authority: Option<String>,
+    authority: Option<Expr>,
     #[attribute(expected = r#"Specify the response type like so: `response = ResponseType`"#)]
     response: Option<Type>,
     #[attribute(expected = r#"Specify the error type like so: `error = ErrorType`"#)]
@@ -761,7 +761,7 @@ struct FileConfigAttribute {
     metadata: Option<Type>,
     #[attribute(expected = r#"Specify the block size like so: `block_size = 65_536`"#)]
     block_size: Option<usize>,
-    authority: Option<String>,
+    authority: Option<Expr>,
     files_name: Option<String>,
     blocks_name: Option<String>,
     #[attribute(expected = r#"Specify the the path to `core` like so: `core = bosaidb::core`"#)]

--- a/crates/bonsaidb-server/src/server.rs
+++ b/crates/bonsaidb-server/src/server.rs
@@ -42,7 +42,7 @@ use crate::config::AcmeConfiguration;
 use crate::dispatch::{register_api_handlers, ServerDispatcher};
 use crate::error::Error;
 use crate::hosted::{Hosted, SerializablePrivateKey, TlsCertificate, TlsCertificatesByDomain};
-use crate::server::shutdown::{Shutdown, ShutdownState};
+use crate::server::shutdown::{Shutdown, ShutdownState, ShutdownStateWatcher};
 use crate::{Backend, BackendError, NoBackend, ServerConfiguration};
 
 #[cfg(feature = "acme")]
@@ -91,7 +91,6 @@ struct Data<B: Backend = NoBackend> {
     clients: RwLock<HashMap<u32, ConnectedClient<B>>>,
     request_processor: flume::Sender<ClientRequest<B>>,
     default_session: Session,
-    endpoint: RwLock<Option<Endpoint>>,
     client_simultaneous_request_limit: usize,
     primary_tls_key: CachedCertifiedKey,
     primary_domain: String,
@@ -171,7 +170,6 @@ impl<B: Backend> CustomServer<B> {
             data: Arc::new(Data {
                 backend: configuration.backend,
                 clients: parking_lot::RwLock::default(),
-                endpoint: RwLock::default(),
                 request_processor: request_sender,
                 default_session: Session {
                     permissions: default_permissions,
@@ -379,10 +377,6 @@ impl<B: Backend> CustomServer<B> {
         builder.set_max_idle_timeout(None)?;
         builder.set_server_key_pair(Some(keypair));
         let mut server = builder.build()?;
-        {
-            let mut endpoint = self.data.endpoint.write();
-            *endpoint = Some(server.clone());
-        }
 
         let mut shutdown_watcher = self
             .data
@@ -397,7 +391,6 @@ impl<B: Backend> CustomServer<B> {
                 if matches!(shutdown_state, ShutdownState::GracefulShutdown) {
                     server.wait_idle().await;
                 }
-                drop(server.close());
                 None
             },
             msg = server.next() => msg
@@ -530,13 +523,13 @@ impl<B: Backend> CustomServer<B> {
                                     break;
                                 }
                             }
-                            let _ = connection.close().await;
                         });
 
                         let task_self = self.clone();
+                        let Some(shutdown) = self.data.shutdown.watcher().await else { return Ok(()) };
                         tokio::spawn(async move {
                             if let Err(err) = task_self
-                                .handle_stream(disconnector, sender, receiver)
+                                .handle_stream(disconnector, sender, receiver, shutdown)
                                 .await
                             {
                                 log::error!("[server] Error handling stream: {err:?}");
@@ -561,6 +554,7 @@ impl<B: Backend> CustomServer<B> {
         client: ConnectedClient<B>,
         request_receiver: flume::Receiver<Payload>,
         response_sender: flume::Sender<Payload>,
+        mut shutdown: ShutdownStateWatcher,
     ) {
         let notify = Arc::new(Notify::new());
         let requests_in_queue = Arc::new(AtomicUsize::new(0));
@@ -578,7 +572,22 @@ impl<B: Backend> CustomServer<B> {
                 )
                 .is_ok()
             {
-                let Ok(payload) = request_receiver.recv_async().await else { break };
+                let payload = 'payload: loop {
+                    tokio::select! {
+                        payload = request_receiver.recv_async() => {
+                            if let Ok(payload) = payload {
+                                break 'payload payload
+                            }
+
+                            return
+                        },
+                        state = shutdown.wait_for_shutdown() => {
+                            if matches!(state, ShutdownState::Shutdown | ShutdownState::GracefulShutdown) {
+                                return
+                            }
+                        }
+                    }
+                };
                 let session_id = payload.session_id;
                 let id = payload.id;
                 let task_sender = response_sender.clone();
@@ -651,12 +660,31 @@ impl<B: Backend> CustomServer<B> {
         client: OwnedClient<B>,
         sender: fabruic::Sender<Payload>,
         mut receiver: fabruic::Receiver<Payload>,
+        mut shutdown: ShutdownStateWatcher,
     ) -> Result<(), Error> {
         let (payload_sender, payload_receiver) = flume::unbounded();
-        tokio::spawn(async move {
-            while let Ok(payload) = payload_receiver.recv_async().await {
-                if sender.send(&payload).is_err() {
-                    break;
+        tokio::spawn({
+            let mut shutdown = shutdown.clone();
+            async move {
+                'stream: loop {
+                    let payload = loop {
+                        tokio::select! {
+                            payload = payload_receiver.recv_async() => {
+                                if let Ok(payload) = payload {
+                                    break payload
+                                }
+                                break 'stream
+                            }
+                            shutdown = shutdown.wait_for_shutdown() => {
+                                if matches!(shutdown, ShutdownState::Shutdown | ShutdownState::GracefulShutdown) {
+                                    break 'stream
+                                }
+                            }
+                        }
+                    };
+                    if sender.send(&payload).is_err() {
+                        break;
+                    }
                 }
             }
         });
@@ -664,17 +692,41 @@ impl<B: Backend> CustomServer<B> {
         let (request_sender, request_receiver) =
             flume::bounded::<Payload>(self.data.client_simultaneous_request_limit);
         let task_self = self.clone();
-        tokio::spawn(async move {
-            task_self
-                .handle_client_requests(client.clone(), request_receiver, payload_sender)
-                .await;
+        tokio::spawn({
+            let shutdown = shutdown.clone();
+            async move {
+                task_self
+                    .handle_client_requests(
+                        client.clone(),
+                        request_receiver,
+                        payload_sender,
+                        shutdown,
+                    )
+                    .await;
+            }
         });
 
-        while let Some(payload) = receiver.next().await {
+        loop {
+            let payload = loop {
+                tokio::select! {
+                    payload = receiver.next() => {
+                        if let Some(payload) = payload {
+                            break payload
+                        }
+
+                        receiver.finish().await?;
+
+                        return Ok(());
+                    }
+                    shutdown = shutdown.wait_for_shutdown() => {
+                        if matches!(shutdown, ShutdownState::Shutdown | ShutdownState::GracefulShutdown) {
+                            return Ok(());
+                        }
+                    }
+                }
+            };
             drop(request_sender.send_async(payload?).await);
         }
-
-        Ok(())
     }
 
     /// Shuts the server down. If a `timeout` is provided, the server will stop

--- a/crates/bonsaidb-server/src/server/connected_client.rs
+++ b/crates/bonsaidb-server/src/server/connected_client.rs
@@ -296,9 +296,8 @@ impl<B: Backend> Drop for OwnedClient<B> {
     fn drop(&mut self) {
         let id = self.client.data.id;
         let server = self.server.take().unwrap();
-        self.runtime.spawn(async move {
-            server.disconnect_client(id).await;
-        });
+        self.runtime
+            .spawn(async move { server.disconnect_client(id).await });
     }
 }
 

--- a/crates/bonsaidb-server/src/server/shutdown.rs
+++ b/crates/bonsaidb-server/src/server/shutdown.rs
@@ -63,6 +63,7 @@ impl Shutdown {
     }
 }
 
+#[derive(Clone)]
 pub struct ShutdownStateWatcher {
     receiver: watch::Receiver<ShutdownState>,
 }

--- a/crates/bonsaidb-server/src/server/websockets.rs
+++ b/crates/bonsaidb-server/src/server/websockets.rs
@@ -156,9 +156,10 @@ impl<B: Backend> CustomServer<B> {
         let (request_sender, request_receiver) =
             flume::bounded::<Payload>(self.data.client_simultaneous_request_limit);
         let task_self = self.clone();
+        let Some(shutdown) = self.data.shutdown.watcher().await else { return };
         tokio::spawn(async move {
             task_self
-                .handle_client_requests(client.clone(), request_receiver, response_sender)
+                .handle_client_requests(client.clone(), request_receiver, response_sender, shutdown)
                 .await;
         });
 

--- a/crates/bonsaidb/Cargo.toml
+++ b/crates/bonsaidb/Cargo.toml
@@ -29,6 +29,10 @@ required-features = ["server", "client"]
 name = "apis"
 required-features = ["server", "client"]
 
+[[test]]
+name = "sessions"
+required-features = ["server", "client", "async"]
+
 [features]
 default = []
 full = ["local-full", "server-full", "client-full", "files"]

--- a/crates/bonsaidb/tests/sessions.rs
+++ b/crates/bonsaidb/tests/sessions.rs
@@ -1,0 +1,113 @@
+//! Tests breaking a connection and detecting it on the Client.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bonsaidb::client::url::Url;
+use bonsaidb::client::Client;
+use bonsaidb::core::test_util::{Basic, TestDirectory};
+use bonsaidb::local::config::Builder;
+use bonsaidb::server::{DefaultPermissions, Server, ServerConfiguration};
+use bonsaidb_core::connection::{AsyncStorageConnection, HasSession, SensitiveString};
+use bonsaidb_core::schema::SerializedCollection;
+
+#[tokio::test]
+async fn sessions() -> anyhow::Result<()> {
+    println!("here");
+    let dir = TestDirectory::new("sessions.bonsaidb");
+    let server = Server::open(
+        ServerConfiguration::new(&dir)
+            .default_permissions(DefaultPermissions::AllowAll)
+            .with_schema::<Basic>()?,
+    )
+    .await?;
+    println!("Installing cert");
+    server.install_self_signed_certificate(false).await?;
+
+    let user_id = server.create_user("ecton").await?;
+    server
+        .set_user_password(user_id, SensitiveString::from("hunter2"))
+        .await?;
+
+    let certificate = server
+        .certificate_chain()
+        .await?
+        .into_end_entity_certificate();
+
+    let reboot = Arc::new(tokio::sync::Notify::new());
+    let rebooted = Arc::new(tokio::sync::Notify::new());
+
+    tokio::spawn({
+        let reboot = reboot.clone();
+        let rebooted = rebooted.clone();
+        async move {
+            // Start listening
+            println!("Listening");
+            tokio::spawn({
+                let server = server.clone();
+                async move {
+                    server.listen_on(12346).await.unwrap();
+                    println!("Stopped listening.");
+                }
+            });
+
+            // Wait for the client to signal that we can disconnect.
+            reboot.notified().await;
+            println!("Server Shutting down.");
+            // Completely shut the server down and restart it.
+            server.shutdown(None).await.unwrap();
+            drop(server);
+            println!("Server shut down.");
+            // Give time for the endpoint to completley close.
+            // TODO this is stupid
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let server = Server::open(
+                ServerConfiguration::new(&dir)
+                    .default_permissions(DefaultPermissions::AllowAll)
+                    .with_schema::<Basic>()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+            println!("Server listening again.");
+            rebooted.notify_one();
+            server.listen_on(12346).await.unwrap();
+        }
+    });
+
+    let client = Client::build(Url::parse("bonsaidb://localhost:12346")?)
+        .with_certificate(certificate.clone())
+        .finish()?;
+
+    println!("Authenticating.");
+    let authenticated = client
+        .authenticate_with_password("ecton", SensitiveString::from("hunter2"))
+        .await?;
+    println!("Creating db");
+    let db = client.create_database::<Basic>("basic", true).await?;
+    // Verify we have a session at this point.
+    authenticated
+        .session()
+        .unwrap()
+        .id
+        .expect("session should be present");
+
+    reboot.notify_one();
+    rebooted.notified().await;
+    // Give the listener a moment to become established.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    println!("Continuing client.");
+
+    // Get a disconnection error
+    assert!(Basic::get_async(&0, &db).await.is_err());
+    println!("Reconnecting");
+    // Reconnect
+    assert!(Basic::get_async(&0, &db).await.unwrap().is_none());
+    println!("Checking session");
+    // Verify the client recognizes it was de-authenticated
+    assert!(client.session().unwrap().id.is_none());
+
+    println!("Done");
+    Ok(())
+}


### PR DESCRIPTION
Closes #271

- [ ] Blocked by https://github.com/khonsulabs/fabruic/issues/50

This PR addresses the ability for a Client to recognize that it has lost its authentication. In the process of adding this, I wrote a test that keeps a client active rather than dropping all clients, and I discovered the Server didn't fully shut down. I believe I've fixed all the BonsaiDb-specific issues, but in the process, I think I discovered a bug in Fabruic that is preventing the port from being reused. This may ultimately be a bug in my own logic somewhere still.