### PR TITLE
Cow tools

### DIFF
--- a/crates/bonsaidb-core/src/connection.rs
+++ b/crates/bonsaidb-core/src/connection.rs
@@ -1,4 +1,4 @@
-use std::borrow::{Borrow, Cow};
+use std::borrow::Borrow;
 use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
@@ -17,7 +17,7 @@ use crate::admin::{Role, User};
 use crate::document::{
     CollectionDocument, CollectionHeader, Document, HasHeader, Header, OwnedDocument,
 };
-use crate::key::{IntoPrefixRange, Key, KeyEncoding};
+use crate::key::{ByteCow, IntoPrefixRange, Key, KeyEncoding};
 use crate::permissions::Permissions;
 use crate::schema::view::map::MappedDocuments;
 use crate::schema::{
@@ -2340,7 +2340,7 @@ impl SerializedQueryKey {
         &self,
     ) -> Result<QueryKey<'static, K>, Error> {
         match self {
-            Self::Matches(key) => K::from_ord_bytes(Cow::Borrowed(key.as_ref()))
+            Self::Matches(key) => K::from_ord_bytes(ByteCow::Borrowed(key.as_ref()))
                 .map_err(|err| Error::other("key serialization", err))
                 .map(|key| QueryKey::Matches(MaybeOwned::Owned(key))),
             Self::Range(range) => Ok(QueryKey::Range(RangeRef::owned(
@@ -2352,7 +2352,7 @@ impl SerializedQueryKey {
                 let keys = keys
                     .iter()
                     .map(|key| {
-                        K::from_ord_bytes(Cow::Borrowed(key.as_ref()))
+                        K::from_ord_bytes(ByteCow::Borrowed(key.as_ref()))
                             .map(MaybeOwned::Owned)
                             .map_err(|err| Error::other("key serialization", err))
                     })
@@ -2584,10 +2584,10 @@ impl Bound<Bytes> {
     ) -> Result<Bound<T>, <T as KeyEncoding<'_, T>>::Error> {
         match self {
             Self::Unbounded => Ok(Bound::Unbounded),
-            Self::Included(value) => Ok(Bound::Included(T::from_ord_bytes(Cow::Borrowed(
+            Self::Included(value) => Ok(Bound::Included(T::from_ord_bytes(ByteCow::Borrowed(
                 value.as_ref(),
             ))?)),
-            Self::Excluded(value) => Ok(Bound::Excluded(T::from_ord_bytes(Cow::Borrowed(
+            Self::Excluded(value) => Ok(Bound::Excluded(T::from_ord_bytes(ByteCow::Borrowed(
                 value.as_ref(),
             ))?)),
         }
@@ -3393,7 +3393,7 @@ impl DerefMut for SensitiveString {
 }
 
 impl<'k> Key<'k> for SensitiveString {
-    fn from_ord_bytes(bytes: Cow<'k, [u8]>) -> Result<Self, Self::Error> {
+    fn from_ord_bytes<'b>(bytes: ByteCow<'k, 'b>) -> Result<Self, Self::Error> {
         String::from_ord_bytes(bytes).map(Self)
     }
 }
@@ -3448,7 +3448,7 @@ impl DerefMut for SensitiveBytes {
 }
 
 impl<'k> Key<'k> for SensitiveBytes {
-    fn from_ord_bytes(bytes: Cow<'k, [u8]>) -> Result<Self, Self::Error> {
+    fn from_ord_bytes<'b>(bytes: ByteCow<'k, 'b>) -> Result<Self, Self::Error> {
         Bytes::from_ord_bytes(bytes).map(Self)
     }
 }

--- a/crates/bonsaidb-core/src/connection.rs
+++ b/crates/bonsaidb-core/src/connection.rs
@@ -3393,6 +3393,8 @@ impl DerefMut for SensitiveString {
 }
 
 impl<'k> Key<'k> for SensitiveString {
+    const CAN_OWN_BYTES: bool = String::CAN_OWN_BYTES;
+
     fn from_ord_bytes<'b>(bytes: ByteCow<'k, 'b>) -> Result<Self, Self::Error> {
         String::from_ord_bytes(bytes).map(Self)
     }
@@ -3448,6 +3450,8 @@ impl DerefMut for SensitiveBytes {
 }
 
 impl<'k> Key<'k> for SensitiveBytes {
+    const CAN_OWN_BYTES: bool = Bytes::CAN_OWN_BYTES;
+
     fn from_ord_bytes<'b>(bytes: ByteCow<'k, 'b>) -> Result<Self, Self::Error> {
         Bytes::from_ord_bytes(bytes).map(Self)
     }

--- a/crates/bonsaidb-core/src/connection/lowlevel.rs
+++ b/crates/bonsaidb-core/src/connection/lowlevel.rs
@@ -1,4 +1,4 @@
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 use std::collections::BTreeMap;
 
 use arc_bytes::serde::Bytes;
@@ -289,7 +289,7 @@ pub trait LowLevelConnection: HasSchema + HasSession {
             .into_iter()
             .map(|mapping| {
                 Ok(Map {
-                    key: <V::Key as key::Key>::from_ord_bytes(&mapping.key)
+                    key: <V::Key as key::Key>::from_ord_bytes(Cow::Borrowed(&mapping.key))
                         .map_err(view::Error::key_serialization)
                         .map_err(Error::from)?,
                     value: V::deserialize(&mapping.value)?,
@@ -429,7 +429,8 @@ pub trait LowLevelConnection: HasSchema + HasSession {
         .into_iter()
         .map(|map| {
             Ok(MappedValue::new(
-                V::Key::from_ord_bytes(&map.key).map_err(view::Error::key_serialization)?,
+                V::Key::from_ord_bytes(Cow::Borrowed(&map.key))
+                    .map_err(view::Error::key_serialization)?,
                 V::deserialize(&map.value)?,
             ))
         })
@@ -915,7 +916,7 @@ pub trait AsyncLowLevelConnection: HasSchema + HasSession + Send + Sync {
             .into_iter()
             .map(|mapping| {
                 Ok(Map {
-                    key: <V::Key as key::Key>::from_ord_bytes(&mapping.key)
+                    key: <V::Key as key::Key>::from_ord_bytes(Cow::Borrowed(&mapping.key))
                         .map_err(view::Error::key_serialization)
                         .map_err(Error::from)?,
                     value: V::deserialize(&mapping.value)?,
@@ -1053,7 +1054,8 @@ pub trait AsyncLowLevelConnection: HasSchema + HasSession + Send + Sync {
         .into_iter()
         .map(|map| {
             Ok(MappedValue::new(
-                V::Key::from_ord_bytes(&map.key).map_err(view::Error::key_serialization)?,
+                V::Key::from_ord_bytes(Cow::Borrowed(&map.key))
+                    .map_err(view::Error::key_serialization)?,
                 V::deserialize(&map.value)?,
             ))
         })

--- a/crates/bonsaidb-core/src/connection/lowlevel.rs
+++ b/crates/bonsaidb-core/src/connection/lowlevel.rs
@@ -1,4 +1,4 @@
-use std::borrow::{Borrow, Cow};
+use std::borrow::Borrow;
 use std::collections::BTreeMap;
 
 use arc_bytes::serde::Bytes;
@@ -11,7 +11,7 @@ use crate::connection::{
 use crate::document::{
     CollectionDocument, CollectionHeader, Document, DocumentId, HasHeader, Header, OwnedDocument,
 };
-use crate::key::{self, Key, KeyEncoding};
+use crate::key::{self, ByteCow, Key, KeyEncoding};
 use crate::schema::view::map::{MappedDocuments, MappedSerializedValue};
 use crate::schema::view::{self};
 use crate::schema::{
@@ -289,7 +289,7 @@ pub trait LowLevelConnection: HasSchema + HasSession {
             .into_iter()
             .map(|mapping| {
                 Ok(Map {
-                    key: <V::Key as key::Key>::from_ord_bytes(Cow::Borrowed(&mapping.key))
+                    key: <V::Key as key::Key>::from_ord_bytes(ByteCow::Borrowed(&mapping.key))
                         .map_err(view::Error::key_serialization)
                         .map_err(Error::from)?,
                     value: V::deserialize(&mapping.value)?,
@@ -429,7 +429,7 @@ pub trait LowLevelConnection: HasSchema + HasSession {
         .into_iter()
         .map(|map| {
             Ok(MappedValue::new(
-                V::Key::from_ord_bytes(Cow::Borrowed(&map.key))
+                V::Key::from_ord_bytes(ByteCow::Borrowed(&map.key))
                     .map_err(view::Error::key_serialization)?,
                 V::deserialize(&map.value)?,
             ))
@@ -916,7 +916,7 @@ pub trait AsyncLowLevelConnection: HasSchema + HasSession + Send + Sync {
             .into_iter()
             .map(|mapping| {
                 Ok(Map {
-                    key: <V::Key as key::Key>::from_ord_bytes(Cow::Borrowed(&mapping.key))
+                    key: <V::Key as key::Key>::from_ord_bytes(ByteCow::Borrowed(&mapping.key))
                         .map_err(view::Error::key_serialization)
                         .map_err(Error::from)?,
                     value: V::deserialize(&mapping.value)?,
@@ -1054,7 +1054,7 @@ pub trait AsyncLowLevelConnection: HasSchema + HasSession + Send + Sync {
         .into_iter()
         .map(|map| {
             Ok(MappedValue::new(
-                V::Key::from_ord_bytes(Cow::Borrowed(&map.key))
+                V::Key::from_ord_bytes(ByteCow::Borrowed(&map.key))
                     .map_err(view::Error::key_serialization)?,
                 V::deserialize(&map.value)?,
             ))

--- a/crates/bonsaidb-core/src/document/id.rs
+++ b/crates/bonsaidb-core/src/document/id.rs
@@ -209,6 +209,14 @@ impl<'a> TryFrom<&'a [u8]> for DocumentId {
     }
 }
 
+impl<'a> TryFrom<Cow<'a, [u8]>> for DocumentId {
+    type Error = crate::Error;
+
+    fn try_from(bytes: Cow<'a, [u8]>) -> Result<Self, Self::Error> {
+        Self::try_from(bytes.as_ref())
+    }
+}
+
 impl<const N: usize> TryFrom<[u8; N]> for DocumentId {
     type Error = crate::Error;
 
@@ -255,7 +263,7 @@ impl DocumentId {
 
     /// Returns the contained value, deserialized back to its original type.
     pub fn deserialize<'a, PrimaryKey: Key<'a>>(&'a self) -> Result<PrimaryKey, crate::Error> {
-        PrimaryKey::from_ord_bytes(self.as_ref())
+        PrimaryKey::from_ord_bytes(Cow::Borrowed(self.as_ref()))
             .map_err(|err| crate::Error::other("key serialization", err))
     }
 }
@@ -296,7 +304,7 @@ impl<'de> Visitor<'de> for DocumentIdVisitor {
 }
 
 impl<'k> Key<'k> for DocumentId {
-    fn from_ord_bytes(bytes: &'k [u8]) -> Result<Self, Self::Error> {
+    fn from_ord_bytes(bytes: Cow<'k, [u8]>) -> Result<Self, Self::Error> {
         Self::try_from(bytes)
     }
 }

--- a/crates/bonsaidb-core/src/document/id.rs
+++ b/crates/bonsaidb-core/src/document/id.rs
@@ -10,7 +10,7 @@ use serde::de::Visitor;
 use serde::{Deserialize, Serialize};
 use tinyvec::{Array, TinyVec};
 
-use crate::key::{Key, KeyEncoding};
+use crate::key::{ByteCow, Key, KeyEncoding};
 
 /// The serialized representation of a document's unique ID.
 #[derive(Default, Ord, Hash, Eq, PartialEq, PartialOrd, Clone)]
@@ -217,6 +217,14 @@ impl<'a> TryFrom<Cow<'a, [u8]>> for DocumentId {
     }
 }
 
+impl<'a, 'b> TryFrom<ByteCow<'a, 'b>> for DocumentId {
+    type Error = crate::Error;
+
+    fn try_from(bytes: ByteCow<'a, 'b>) -> Result<Self, Self::Error> {
+        Self::try_from(bytes.as_ref())
+    }
+}
+
 impl<const N: usize> TryFrom<[u8; N]> for DocumentId {
     type Error = crate::Error;
 
@@ -263,7 +271,7 @@ impl DocumentId {
 
     /// Returns the contained value, deserialized back to its original type.
     pub fn deserialize<'a, PrimaryKey: Key<'a>>(&'a self) -> Result<PrimaryKey, crate::Error> {
-        PrimaryKey::from_ord_bytes(Cow::Borrowed(self.as_ref()))
+        PrimaryKey::from_ord_bytes(ByteCow::Borrowed(self.as_ref()))
             .map_err(|err| crate::Error::other("key serialization", err))
     }
 }
@@ -304,7 +312,7 @@ impl<'de> Visitor<'de> for DocumentIdVisitor {
 }
 
 impl<'k> Key<'k> for DocumentId {
-    fn from_ord_bytes(bytes: Cow<'k, [u8]>) -> Result<Self, Self::Error> {
+    fn from_ord_bytes<'b>(bytes: ByteCow<'k, 'b>) -> Result<Self, Self::Error> {
         Self::try_from(bytes)
     }
 }

--- a/crates/bonsaidb-core/src/document/id.rs
+++ b/crates/bonsaidb-core/src/document/id.rs
@@ -217,14 +217,6 @@ impl<'a> TryFrom<Cow<'a, [u8]>> for DocumentId {
     }
 }
 
-impl<'a, 'b> TryFrom<ByteCow<'a, 'b>> for DocumentId {
-    type Error = crate::Error;
-
-    fn try_from(bytes: ByteCow<'a, 'b>) -> Result<Self, Self::Error> {
-        Self::try_from(bytes.as_ref())
-    }
-}
-
 impl<const N: usize> TryFrom<[u8; N]> for DocumentId {
     type Error = crate::Error;
 
@@ -312,8 +304,10 @@ impl<'de> Visitor<'de> for DocumentIdVisitor {
 }
 
 impl<'k> Key<'k> for DocumentId {
+    const CAN_OWN_BYTES: bool = false;
+
     fn from_ord_bytes<'b>(bytes: ByteCow<'k, 'b>) -> Result<Self, Self::Error> {
-        Self::try_from(bytes)
+        Self::try_from(bytes.as_ref())
     }
 }
 

--- a/crates/bonsaidb-core/src/key/time.rs
+++ b/crates/bonsaidb-core/src/key/time.rs
@@ -9,6 +9,8 @@ use crate::key::time::limited::{BonsaiEpoch, UnixEpoch};
 use crate::key::{ByteCow, Key, KeyEncoding};
 
 impl<'a> Key<'a> for Duration {
+    const CAN_OWN_BYTES: bool = false;
+
     fn from_ord_bytes<'b>(bytes: ByteCow<'a, 'b>) -> Result<Self, Self::Error> {
         let merged = u128::decode_variable(bytes.as_ref()).map_err(|_| TimeError::InvalidValue)?;
         let seconds = u64::try_from(merged >> 30).map_err(|_| TimeError::DeltaNotRepresentable)?;
@@ -46,6 +48,8 @@ fn duration_key_tests() {
 }
 
 impl<'a> Key<'a> for SystemTime {
+    const CAN_OWN_BYTES: bool = false;
+
     fn from_ord_bytes<'b>(bytes: ByteCow<'a, 'b>) -> Result<Self, Self::Error> {
         let since_epoch = Duration::from_ord_bytes(bytes)?;
         UNIX_EPOCH
@@ -271,6 +275,8 @@ pub mod limited {
     where
         Resolution: TimeResolution,
     {
+        const CAN_OWN_BYTES: bool = false;
+
         fn from_ord_bytes<'b>(bytes: ByteCow<'a, 'b>) -> Result<Self, Self::Error> {
             let representation =
                 <Resolution::Representation as Variable>::decode_variable(bytes.as_ref())
@@ -1112,6 +1118,8 @@ pub mod limited {
         Resolution: TimeResolution,
         Epoch: TimeEpoch,
     {
+        const CAN_OWN_BYTES: bool = false;
+
         fn from_ord_bytes<'b>(bytes: ByteCow<'a, 'b>) -> Result<Self, Self::Error> {
             let duration = LimitedResolutionDuration::<Resolution>::from_ord_bytes(bytes)?;
             Ok(Self::from(duration))

--- a/crates/bonsaidb-core/src/keyvalue/timestamp.rs
+++ b/crates/bonsaidb-core/src/keyvalue/timestamp.rs
@@ -74,14 +74,14 @@ impl std::ops::Add<Duration> for Timestamp {
 }
 
 impl<'a> Key<'a> for Timestamp {
-    fn from_ord_bytes(bytes: &'a [u8]) -> Result<Self, Self::Error> {
+    fn from_ord_bytes(bytes: Cow<'a, [u8]>) -> Result<Self, Self::Error> {
         if bytes.len() != 12 {
             return Err(IncorrectByteLength);
         }
 
         Ok(Self {
-            seconds: u64::from_ord_bytes(&bytes[0..8])?,
-            nanos: u32::from_ord_bytes(&bytes[8..12])?,
+            seconds: u64::from_ord_bytes(Cow::Borrowed(&bytes.as_ref()[0..8]))?,
+            nanos: u32::from_ord_bytes(Cow::Borrowed(&bytes.as_ref()[8..12]))?,
         })
     }
 }
@@ -102,7 +102,7 @@ impl<'a> KeyEncoding<'a, Self> for Timestamp {
 fn key_test() {
     let original = Timestamp::now();
     assert_eq!(
-        Timestamp::from_ord_bytes(&original.as_ord_bytes().unwrap()).unwrap(),
+        Timestamp::from_ord_bytes(Cow::Borrowed(&original.as_ord_bytes().unwrap())).unwrap(),
         original
     );
 }

--- a/crates/bonsaidb-core/src/keyvalue/timestamp.rs
+++ b/crates/bonsaidb-core/src/keyvalue/timestamp.rs
@@ -74,6 +74,8 @@ impl std::ops::Add<Duration> for Timestamp {
 }
 
 impl<'a> Key<'a> for Timestamp {
+    const CAN_OWN_BYTES: bool = false;
+
     fn from_ord_bytes<'b>(bytes: ByteCow<'a, 'b>) -> Result<Self, Self::Error> {
         if bytes.as_ref().len() != 12 {
             return Err(IncorrectByteLength);

--- a/crates/bonsaidb-core/src/keyvalue/timestamp.rs
+++ b/crates/bonsaidb-core/src/keyvalue/timestamp.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-use crate::key::{IncorrectByteLength, Key, KeyEncoding};
+use crate::key::{ByteCow, IncorrectByteLength, Key, KeyEncoding};
 
 /// A timestamp relative to [`UNIX_EPOCH`].
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Default)]
@@ -74,14 +74,14 @@ impl std::ops::Add<Duration> for Timestamp {
 }
 
 impl<'a> Key<'a> for Timestamp {
-    fn from_ord_bytes(bytes: Cow<'a, [u8]>) -> Result<Self, Self::Error> {
-        if bytes.len() != 12 {
+    fn from_ord_bytes<'b>(bytes: ByteCow<'a, 'b>) -> Result<Self, Self::Error> {
+        if bytes.as_ref().len() != 12 {
             return Err(IncorrectByteLength);
         }
 
         Ok(Self {
-            seconds: u64::from_ord_bytes(Cow::Borrowed(&bytes.as_ref()[0..8]))?,
-            nanos: u32::from_ord_bytes(Cow::Borrowed(&bytes.as_ref()[8..12]))?,
+            seconds: u64::from_ord_bytes(ByteCow::Borrowed(&bytes.as_ref()[0..8]))?,
+            nanos: u32::from_ord_bytes(ByteCow::Borrowed(&bytes.as_ref()[8..12]))?,
         })
     }
 }
@@ -102,7 +102,7 @@ impl<'a> KeyEncoding<'a, Self> for Timestamp {
 fn key_test() {
     let original = Timestamp::now();
     assert_eq!(
-        Timestamp::from_ord_bytes(Cow::Borrowed(&original.as_ord_bytes().unwrap())).unwrap(),
+        Timestamp::from_ord_bytes(ByteCow::Borrowed(&original.as_ord_bytes().unwrap())).unwrap(),
         original
     );
 }

--- a/crates/bonsaidb-core/src/schema/schematic.rs
+++ b/crates/bonsaidb-core/src/schema/schematic.rs
@@ -1,5 +1,4 @@
 use std::any::TypeId;
-use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -7,7 +6,7 @@ use std::marker::PhantomData;
 use derive_where::derive_where;
 
 use crate::document::{BorrowedDocument, DocumentId, KeyId};
-use crate::key::Key;
+use crate::key::{ByteCow, Key};
 use crate::schema::collection::Collection;
 use crate::schema::view::map::{self, MappedValue};
 use crate::schema::view::{self, Serialized, SerializedView, ViewSchema};
@@ -245,7 +244,7 @@ where
         let mappings = mappings
             .iter()
             .map(
-                |(key, value)| match <V::Key as Key>::from_ord_bytes(Cow::Borrowed(key)) {
+                |(key, value)| match <V::Key as Key>::from_ord_bytes(ByteCow::Borrowed(key)) {
                     Ok(key) => {
                         let value = V::deserialize(value)?;
                         Ok(MappedValue::new(key, value))

--- a/crates/bonsaidb-core/src/schema/schematic.rs
+++ b/crates/bonsaidb-core/src/schema/schematic.rs
@@ -1,4 +1,5 @@
 use std::any::TypeId;
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -243,13 +244,15 @@ where
     fn reduce(&self, mappings: &[(&[u8], &[u8])], rereduce: bool) -> Result<Vec<u8>, view::Error> {
         let mappings = mappings
             .iter()
-            .map(|(key, value)| match <V::Key as Key>::from_ord_bytes(key) {
-                Ok(key) => {
-                    let value = V::deserialize(value)?;
-                    Ok(MappedValue::new(key, value))
-                }
-                Err(err) => Err(view::Error::key_serialization(err)),
-            })
+            .map(
+                |(key, value)| match <V::Key as Key>::from_ord_bytes(Cow::Borrowed(key)) {
+                    Ok(key) => {
+                        let value = V::deserialize(value)?;
+                        Ok(MappedValue::new(key, value))
+                    }
+                    Err(err) => Err(view::Error::key_serialization(err)),
+                },
+            )
             .collect::<Result<Vec<_>, view::Error>>()?;
 
         let reduced_value = self.schema.reduce(&mappings, rereduce)?;

--- a/crates/bonsaidb-core/src/schema/view.rs
+++ b/crates/bonsaidb-core/src/schema/view.rs
@@ -7,7 +7,7 @@ use transmog_pot::Pot;
 
 use crate::connection::{self, AsyncConnection, Connection};
 use crate::document::{BorrowedDocument, CollectionDocument};
-use crate::key::Key;
+use crate::key::{ByteCow, Key};
 use crate::schema::view::map::{Mappings, ViewMappedValue};
 use crate::schema::{Collection, CollectionName, Name, SerializedCollection, ViewName};
 use crate::AnyError;

--- a/crates/bonsaidb-core/src/schema/view/map.rs
+++ b/crates/bonsaidb-core/src/schema/view/map.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
@@ -253,7 +254,7 @@ impl Serialized {
     ) -> Result<Map<View::Key, View::Value>, view::Error> {
         Ok(Map::new(
             self.source.clone(),
-            <View::Key as Key>::from_ord_bytes(&self.key)
+            <View::Key as Key>::from_ord_bytes(Cow::Borrowed(&self.key))
                 .map_err(view::Error::key_serialization)?,
             View::deserialize(&self.value)?,
         ))

--- a/crates/bonsaidb-core/src/schema/view/map.rs
+++ b/crates/bonsaidb-core/src/schema/view/map.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
@@ -6,7 +5,7 @@ use arc_bytes::serde::Bytes;
 use serde::{Deserialize, Serialize};
 
 use crate::document::{DocumentId, Header, OwnedDocument};
-use crate::schema::view::{self, Key, SerializedView, View};
+use crate::schema::view::{self, ByteCow, Key, SerializedView, View};
 
 /// A document's entry in a View's mappings.
 #[derive(Eq, PartialEq, Debug)]
@@ -254,7 +253,7 @@ impl Serialized {
     ) -> Result<Map<View::Key, View::Value>, view::Error> {
         Ok(Map::new(
             self.source.clone(),
-            <View::Key as Key>::from_ord_bytes(Cow::Borrowed(&self.key))
+            <View::Key as Key>::from_ord_bytes(ByteCow::Borrowed(&self.key))
                 .map_err(view::Error::key_serialization)?,
             View::deserialize(&self.value)?,
         ))

--- a/crates/bonsaidb-files/src/schema/file.rs
+++ b/crates/bonsaidb-files/src/schema/file.rs
@@ -492,6 +492,8 @@ enum FileKey<'a> {
 }
 
 impl<'k> Key<'k> for OwnedFileKey {
+    const CAN_OWN_BYTES: bool = false;
+
     fn from_ord_bytes<'b>(bytes: ByteCow<'k, 'b>) -> Result<Self, Self::Error> {
         let mut decoder = CompositeKeyDecoder::new(bytes);
 

--- a/crates/bonsaidb-files/src/schema/file.rs
+++ b/crates/bonsaidb-files/src/schema/file.rs
@@ -491,7 +491,7 @@ enum FileKey<'a> {
 }
 
 impl<'k> Key<'k> for OwnedFileKey {
-    fn from_ord_bytes(bytes: &'k [u8]) -> Result<Self, Self::Error> {
+    fn from_ord_bytes(bytes: Cow<'k, [u8]>) -> Result<Self, Self::Error> {
         let mut decoder = CompositeKeyDecoder::new(bytes);
 
         let path = Cow::Owned(decoder.decode::<String>()?);

--- a/crates/bonsaidb-files/src/schema/file.rs
+++ b/crates/bonsaidb-files/src/schema/file.rs
@@ -7,7 +7,8 @@ use bonsaidb_core::connection::{Bound, BoundRef, Connection, RangeRef, ViewMappi
 use bonsaidb_core::document::{CollectionDocument, Emit};
 use bonsaidb_core::key::time::TimestampAsNanoseconds;
 use bonsaidb_core::key::{
-    CompositeKeyDecoder, CompositeKeyEncoder, CompositeKeyError, IntoPrefixRange, Key, KeyEncoding,
+    ByteCow, CompositeKeyDecoder, CompositeKeyEncoder, CompositeKeyError, IntoPrefixRange, Key,
+    KeyEncoding,
 };
 use bonsaidb_core::schema::{
     Collection, CollectionName, CollectionViewSchema, DefaultSerialization, SerializedCollection,
@@ -491,7 +492,7 @@ enum FileKey<'a> {
 }
 
 impl<'k> Key<'k> for OwnedFileKey {
-    fn from_ord_bytes(bytes: Cow<'k, [u8]>) -> Result<Self, Self::Error> {
+    fn from_ord_bytes<'b>(bytes: ByteCow<'k, 'b>) -> Result<Self, Self::Error> {
         let mut decoder = CompositeKeyDecoder::new(bytes);
 
         let path = Cow::Owned(decoder.decode::<String>()?);

--- a/crates/bonsaidb-macros/src/lib.rs
+++ b/crates/bonsaidb-macros/src/lib.rs
@@ -393,6 +393,7 @@ struct KeyAttribute {
     #[attribute(expected = r#"Specify the the path to `core` like so: `core = bosaidb::core`"#)]
     core: Option<Path>,
     allow_null_bytes: bool,
+    can_own_bytes: bool,
     enum_repr: Option<Type>,
 }
 
@@ -439,6 +440,7 @@ pub fn key_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         core,
         allow_null_bytes,
         enum_repr,
+        can_own_bytes,
     } = KeyAttribute::from_attributes(&attrs).unwrap_or_abort();
 
     if matches!(data, Data::Struct(_)) && enum_repr.is_some() {
@@ -631,6 +633,7 @@ pub fn key_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         # use #core::key::{ByteCow, CompositeKeyDecoder, CompositeKeyEncoder, CompositeKeyError, Key, KeyEncoding};
 
         impl #impl_generics Key<'key> for #ident #ty_generics #where_clause {
+            const CAN_OWN_BYTES: bool = #can_own_bytes;
 
             fn from_ord_bytes<'b>(mut $bytes: ByteCow<'key, 'b>) -> Result<Self, Self::Error> {
 

--- a/crates/bonsaidb-macros/src/lib.rs
+++ b/crates/bonsaidb-macros/src/lib.rs
@@ -628,11 +628,11 @@ pub fn key_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     quote! {
         # use std::{borrow::Cow, io::{self, ErrorKind}};
-        # use #core::key::{CompositeKeyDecoder, CompositeKeyEncoder, CompositeKeyError, Key, KeyEncoding};
+        # use #core::key::{ByteCow, CompositeKeyDecoder, CompositeKeyEncoder, CompositeKeyError, Key, KeyEncoding};
 
         impl #impl_generics Key<'key> for #ident #ty_generics #where_clause {
 
-            fn from_ord_bytes(mut $bytes: std::borrow::Cow<'key, [u8]>) -> Result<Self, Self::Error> {
+            fn from_ord_bytes<'b>(mut $bytes: ByteCow<'key, 'b>) -> Result<Self, Self::Error> {
 
                 let mut $decoder = CompositeKeyDecoder::new($bytes);
 

--- a/crates/bonsaidb-macros/src/lib.rs
+++ b/crates/bonsaidb-macros/src/lib.rs
@@ -632,7 +632,7 @@ pub fn key_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         impl #impl_generics Key<'key> for #ident #ty_generics #where_clause {
 
-            fn from_ord_bytes(mut $bytes: &'key [u8]) -> Result<Self, Self::Error> {
+            fn from_ord_bytes(mut $bytes: std::borrow::Cow<'key, [u8]>) -> Result<Self, Self::Error> {
 
                 let mut $decoder = CompositeKeyDecoder::new($bytes);
 


### PR DESCRIPTION
Swapping `&[u8]` in `from_ord_bytes` for `Cow<'_, [u8]>` leads to some unfortunate performance issues when there's escaping done early. Each nested call needs to allocate to propagate the Owned case.

I have an idea of a way to avoid this overhead, but I need to test some things first

fixes: https://github.com/khonsulabs/bonsaidb/issues/254