### PR TITLE
Some typo fixes in documentation and README files

### DIFF
--- a/crates/bonsaidb-local/README.md
+++ b/crates/bonsaidb-local/README.md
@@ -1,4 +1,4 @@
-# BonsaiDb Client
+# BonsaiDb Local
 
 BonsaiDb's offline database implementation.
 

--- a/crates/bonsaidb-local/src/config.rs
+++ b/crates/bonsaidb-local/src/config.rs
@@ -323,7 +323,7 @@ pub trait Builder: Sized {
     /// Registers the schema and returns self.
     fn with_schema<S: Schema>(self) -> Result<Self, Error>;
 
-    /// Sets [`StorageConfiguration::path`](StorageConfiguration#structfield.memory_only) to true and returns self.
+    /// Sets [`StorageConfiguration::memory_only`](StorageConfiguration#structfield.memory_only) to true and returns self.
     #[must_use]
     fn memory_only(self) -> Self;
     /// Sets [`StorageConfiguration::path`](StorageConfiguration#structfield.path) to `path` and returns self.


### PR DESCRIPTION
Hi, I found some typos that confused me a bit, and in this PR I try to fix them