### PR TITLE
Lifetime for `#[derive(Key)]`

### DIFF
--- a/crates/bonsaidb-macros/Cargo.toml
+++ b/crates/bonsaidb-macros/Cargo.toml
@@ -16,13 +16,13 @@ rust-version = "1.65"
 proc-macro = true
 
 [dependencies]
-attribute-derive = "0.3.1"
+attribute-derive = "0.6.0"
 proc-macro-crate = "1.1.0"
 proc-macro-error = "1"
 proc-macro2 = { version = "1.0.37", features = ["nightly"] }
 quote = "1"
-quote-use = { version = "0.6.0", features = ["namespace_idents"] }
-syn = "1"
+quote-use = { version = "0.7.0", features = ["namespace_idents"] }
+syn = "2"
 trybuild = "1.0.54"
 
 [dev-dependencies]

--- a/crates/bonsaidb-macros/src/lib.rs
+++ b/crates/bonsaidb-macros/src/lib.rs
@@ -540,7 +540,7 @@ pub fn key_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let lifetimes: Vec<_> = generics.lifetimes().cloned().collect();
     let where_clause = generics.make_where_clause();
     for lifetime in lifetimes {
-        where_clause.predicates.push(parse_quote!($'key: #lifetime))
+        where_clause.predicates.push(parse_quote!($'key: #lifetime));
     }
     generics
         .params

--- a/crates/bonsaidb-macros/tests/key.rs
+++ b/crates/bonsaidb-macros/tests/key.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use bonsaidb::core::key::{Key, KeyEncoding};
 
 #[test]
@@ -124,4 +126,18 @@ fn enum_u64() {
         Test::C.as_ord_bytes().unwrap().as_ref(),
         &[255, 255, 255, 255, 255, 255, 255, 255]
     );
+}
+
+#[test]
+fn lifetime() {
+    #[derive(Clone, Debug, Key)]
+    struct Test<'a, 'b>(Cow<'a, str>, Cow<'b, str>);
+
+    assert_eq!(
+        &[97, 0, 98, 0, 1, 1],
+        Test("a".into(), "b".into())
+            .as_ord_bytes()
+            .unwrap()
+            .as_ref()
+    )
 }

--- a/crates/bonsaidb-macros/tests/ui/collection/invalid_attribute.stderr
+++ b/crates/bonsaidb-macros/tests/ui/collection/invalid_attribute.stderr
@@ -4,7 +4,7 @@ error: expected identifier
 4 | #[collection(name = "hi", authority = "hello", "hi")]
   |                                                ^^^^
 
-error: Only `authority = \"some-authority\"`, `name = \"some-name\"`, `views = [SomeView, AnotherView]`, `primary_key = u64`, `natural_id = |contents: &Self| Some(contents.id)`, serialization = SerializationFormat` and `core = bonsaidb::core` are supported attributes
+error: supported fields are `authority`, `name`, `views`, `serialization`, `encryption_key`, `encryption_required`, `encryption_optional`, `primary_key`, `natural_id` and `core`
  --> tests/ui/collection/invalid_attribute.rs:8:48
   |
 8 | #[collection(name = "hi", authority = "hello", field = 200)]

--- a/crates/bonsaidb-macros/tests/ui/collection/missing_name.stderr
+++ b/crates/bonsaidb-macros/tests/ui/collection/missing_name.stderr
@@ -1,4 +1,4 @@
-error: You need to specify the collection name via `#[collection(name = \"name\")]`
+error: required `name` is not specified\n\n= help: try `#[collection(name=\"name\")]`
  --> tests/ui/collection/missing_name.rs:3:10
   |
 3 | #[derive(Collection)]

--- a/crates/bonsaidb-macros/tests/ui/collection/missing_name.stderr
+++ b/crates/bonsaidb-macros/tests/ui/collection/missing_name.stderr
@@ -1,4 +1,6 @@
-error: required `name` is not specified\n\n= help: try `#[collection(name=\"name\")]`
+error: required `name` is not specified
+
+       = help: try `#[collection(name="name")]`
  --> tests/ui/collection/missing_name.rs:3:10
   |
 3 | #[derive(Collection)]

--- a/crates/bonsaidb-macros/tests/ui/schema/invalid_attribute.stderr
+++ b/crates/bonsaidb-macros/tests/ui/schema/invalid_attribute.stderr
@@ -4,7 +4,7 @@ error: expected identifier
 5 | #[schema(name = "name", "hi")]
   |                         ^^^^
 
-error: Only `name = \"name\"`, `authority = \"authority\"`, `collections = [SomeCollection, AnotherCollection]`, `include = [OtherSchema]`, and `core = bonsaidb::core` are supported attributes
+error: supported fields are `name`, `authority`, `collections`, `include` and `core`
  --> tests/ui/schema/invalid_attribute.rs:9:25
   |
 9 | #[schema(name = "name", test = "hi")]

--- a/crates/bonsaidb-macros/tests/ui/schema/missing_name.stderr
+++ b/crates/bonsaidb-macros/tests/ui/schema/missing_name.stderr
@@ -1,4 +1,6 @@
-error: required `name` is not specified\n\n= help: try `#[schema(name=\"name\")]`
+error: required `name` is not specified
+
+       = help: try `#[schema(name="name")]`
  --> tests/ui/schema/missing_name.rs:3:10
   |
 3 | #[derive(Schema)]

--- a/crates/bonsaidb-macros/tests/ui/schema/missing_name.stderr
+++ b/crates/bonsaidb-macros/tests/ui/schema/missing_name.stderr
@@ -1,4 +1,4 @@
-error: You need to specify the schema name via `#[schema(name = \"name\")]`
+error: required `name` is not specified\n\n= help: try `#[schema(name=\"name\")]`
  --> tests/ui/schema/missing_name.rs:3:10
   |
 3 | #[derive(Schema)]

--- a/crates/bonsaidb-macros/tests/ui/view/invalid_attribute.stderr
+++ b/crates/bonsaidb-macros/tests/ui/view/invalid_attribute.stderr
@@ -4,7 +4,7 @@ error: expected identifier
 4 | #[view(name = "hi", "hi")]
   |                     ^^^^
 
-error: Only `collection = CollectionType`, `key = KeyType`, `name = \"by-name\"`, `value = ValueType` and `serialization = SerializationFormat` and `core = bonsaidb::core` are supported attributes
+error: supported fields are `collection`, `key`, `name`, `value`, `core` and `serialization`
  --> tests/ui/view/invalid_attribute.rs:8:21
   |
 8 | #[view(name = "hi", authority = "hello", "hi")]

--- a/crates/bonsaidb-macros/tests/ui/view/missing_collection.stderr
+++ b/crates/bonsaidb-macros/tests/ui/view/missing_collection.stderr
@@ -1,4 +1,6 @@
-error: required `collection` is not specified\n\n= help: try `#[view(collection=CollectionType)]`
+error: required `collection` is not specified
+
+       = help: try `#[view(collection=CollectionType)]`
  --> tests/ui/view/missing_collection.rs:3:10
   |
 3 | #[derive(View)]

--- a/crates/bonsaidb-macros/tests/ui/view/missing_collection.stderr
+++ b/crates/bonsaidb-macros/tests/ui/view/missing_collection.stderr
@@ -1,4 +1,4 @@
-error: You need to specify the collection type via `#[view(collection = CollectionType)]`
+error: required `collection` is not specified\n\n= help: try `#[view(collection=CollectionType)]`
  --> tests/ui/view/missing_collection.rs:3:10
   |
 3 | #[derive(View)]

--- a/crates/bonsaidb-macros/tests/ui/view/missing_key.stderr
+++ b/crates/bonsaidb-macros/tests/ui/view/missing_key.stderr
@@ -1,4 +1,4 @@
-error: You need to specify the key type via `#[view(key = KeyType)]`
+error: required `key` is not specified\n\n= help: try `#[view(key=KeyType)]`
  --> tests/ui/view/missing_key.rs:3:10
   |
 3 | #[derive(View)]

--- a/crates/bonsaidb-macros/tests/ui/view/missing_key.stderr
+++ b/crates/bonsaidb-macros/tests/ui/view/missing_key.stderr
@@ -1,4 +1,6 @@
-error: required `key` is not specified\n\n= help: try `#[view(key=KeyType)]`
+error: required `key` is not specified
+
+       = help: try `#[view(key=KeyType)]`
  --> tests/ui/view/missing_key.rs:3:10
   |
 3 | #[derive(View)]

--- a/crates/bonsaidb-macros/tests/ui/view/missing_name.stderr
+++ b/crates/bonsaidb-macros/tests/ui/view/missing_name.stderr
@@ -1,4 +1,6 @@
-error: required `name` is not specified\n\n= help: try `#[collection(name=\"name\")]`
+error: required `name` is not specified
+
+       = help: try `#[collection(name="name")]`
  --> tests/ui/view/missing_name.rs:3:10
   |
 3 | #[derive(Collection)]

--- a/crates/bonsaidb-macros/tests/ui/view/missing_name.stderr
+++ b/crates/bonsaidb-macros/tests/ui/view/missing_name.stderr
@@ -1,4 +1,4 @@
-error: You need to specify the collection name via `#[collection(name = \"name\")]`
+error: required `name` is not specified\n\n= help: try `#[collection(name=\"name\")]`
  --> tests/ui/view/missing_name.rs:3:10
   |
 3 | #[derive(Collection)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -197,6 +197,10 @@ fn all_tests() -> &'static [TestSuite] {
             cargo_args: "--package bonsaidb-files --no-default-features",
             toolchain: "stable",
         },
+        TestSuite {
+            cargo_args: "--package bonsaidb-macros",
+            toolchain: "stable",
+        },
     ]
 }
 


### PR DESCRIPTION
- update syn, attribute-derive and quote-use
- fix: lifetimes in derive Key

fixes #283

Also fixes an issue where the lifetimes in `#[derive(Key)]` clashed with
lifetime names on the struct (especially `'b`)

