### PR TITLE
Split ViewSchema/MapReduce, add derive(ViewSchema)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ConnectedClient::all_sessions()` is a new function that returns all of the
   active sessions for the given client.
+- View schemas are now partially deriveble, and have had their map/reduce
+  functionality split into their own traits. The following notes all apply to
+  this refactoring:
+  - `ViewSchema::map()` and `ViewSchema::reduce()` have been moved to a new
+    trait: `MapReduce`.
+  - `CollectionViewSchema` has been removed, and the `map()` and `reduce()`
+    functions have been moved to a new trait: `CollectionMapReduce`.
+  - `ViewSchema::unique()` and `ViewSchema::lazy()` have been replaced with
+    `ViewSchema::update_policy()`, which returns a new enum: `ViewUpdatePolicy`.
+    This enum contains three variants: Lazy, Eager, and Unique, allowing the same
+    options that the previous two methods supported without any ambiguities.
+  - `ViewSchema` is now implementable/derivable for all views, regardless of
+    whether the map/reduce functionality utilizes `SerializedCollection`s or
+    not.
+- `ViewSchema::MappedKey<'doc>` is a new associated type with a generic
+  associated lifetime that enables `map()`/`reduce()` to utilize borrowed data
+  for the view's key type. This has caused the `map()` and `reduce()` functions
+  to have new lifetime annotations added. These changes are part of an effort to
+  support more flows where borrowing data is possible to minimize allocations
+  while indexing and querying views.
+
+  For all existing users, setting this associated type to the view's Key type
+  will work, or pasting this associated type definition in:
+
+  ```rust
+  type MappedKey<'doc> = <Self::View as View>::Key
+  ```
 
 ### Added
 
@@ -144,6 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variable integer encoding, allowing for proper cross-architecture behavior.
   When trying to decode a value that is too large for the given target
   architecture, an error will be returned.
+- `ViewSchema` can now be derived.
 - `bonsaidb_core::Error::is_unique_key_error()` is a convenience function to
   quickly check if an error is a result of a unique key violation from a
   specific view.

--- a/book/book-examples/tests/view-example-enum.rs
+++ b/book/book-examples/tests/view-example-enum.rs
@@ -3,7 +3,7 @@ use bonsaidb::core::document::{BorrowedDocument, Emit};
 use bonsaidb::core::key::Key;
 use bonsaidb::core::schema::view::map::ViewMappedValue;
 use bonsaidb::core::schema::{
-    Collection, ReduceResult, SerializedCollection, View, ViewMapResult, ViewSchema,
+    Collection, MapReduce, ReduceResult, SerializedCollection, View, ViewMapResult, ViewSchema,
 };
 use bonsaidb::core::Error;
 use bonsaidb::local::config::{Builder, StorageConfiguration};
@@ -30,14 +30,11 @@ pub struct BlogPost {
 
 // ANCHOR: view
 
-#[derive(Debug, Clone, View)]
+#[derive(Debug, Clone, View, ViewSchema)]
 #[view(collection = BlogPost, key = Option<Category>, value = u32, name = "by-category")]
 pub struct BlogPostsByCategory;
 
-impl ViewSchema for BlogPostsByCategory {
-    type MappedKey<'doc> = Option<Category>;
-    type View = Self;
-
+impl MapReduce for BlogPostsByCategory {
     fn map<'doc>(&self, document: &'doc BorrowedDocument<'_>) -> ViewMapResult<'doc, Self> {
         let post = BlogPost::document_contents(document)?;
         document.header.emit_key_and_value(post.category, 1)

--- a/book/book-examples/tests/view-example-string.rs
+++ b/book/book-examples/tests/view-example-string.rs
@@ -2,7 +2,7 @@ use bonsaidb::core::connection::Connection;
 use bonsaidb::core::document::{BorrowedDocument, Emit};
 use bonsaidb::core::schema::view::map::ViewMappedValue;
 use bonsaidb::core::schema::{
-    Collection, ReduceResult, SerializedCollection, View, ViewMapResult, ViewSchema,
+    Collection, MapReduce, ReduceResult, SerializedCollection, View, ViewMapResult, ViewSchema,
 };
 use bonsaidb::core::Error;
 use bonsaidb::local::config::{Builder, StorageConfiguration};
@@ -20,14 +20,11 @@ pub struct BlogPost {
 // ANCHOR_END: struct
 
 // ANCHOR: view
-#[derive(Debug, Clone, View)]
+#[derive(Debug, Clone, View, ViewSchema)]
 #[view(collection = BlogPost, key = Option<String>, value = u32, name = "by-category")]
 pub struct BlogPostsByCategory;
 
-impl ViewSchema for BlogPostsByCategory {
-    type MappedKey<'doc> = Option<String>;
-    type View = Self;
-
+impl MapReduce for BlogPostsByCategory {
     fn map<'doc>(&self, document: &'doc BorrowedDocument<'_>) -> ViewMapResult<'doc, Self> {
         let post = BlogPost::document_contents(document)?;
         document.header.emit_key_and_value(post.category, 1)

--- a/book/src/about/concepts/view.md
+++ b/book/src/about/concepts/view.md
@@ -24,11 +24,11 @@ While `category` should be an enum, let's first explore using `String` and upgra
 {{#include ../../../book-examples/tests/view-example-string.rs:view}}
 ```
 
-The two traits being implemented are [View][view-trait] and
-[ViewSchema][viewschema-trait]. These traits are designed to allow keeping the
-`View` implementation in a shared code library that is used by both client-side
-and server-side code, while keeping the `ViewSchema` implementation in the
-server executable only.
+The three view-related traits being implemented are [`View`][view-trait],
+[`ViewSchema`][viewschema-trait], and [`MapReduce`][mapreduce-trait]. These
+traits are designed to allow keeping the `View` implementation in a shared code
+library that is used by both client-side and server-side code, while keeping the
+`ViewSchema` and `MapReduce` implementation in the server executable only.
 
 ## Views for [`SerializedCollection`][serialized-collection]
 
@@ -127,6 +127,7 @@ In our previous example, we used `String` for the Key type. The reason is import
 [key]: ../../traits/key.md
 [view-trait]: {{DOCS_BASE_URL}}/bonsaidb/core/schema/trait.View.html
 [viewschema-trait]: {{DOCS_BASE_URL}}/bonsaidb/core/schema/trait.ViewSchema.html
+[mapreduce-trait]: {{DOCS_BASE_URL}}/bonsaidb/core/schema/view/trait.MapReduce.html
 [viewschema-version]: {{DOCS_BASE_URL}}/bonsaidb/core/schema/trait.ViewSchema.html#method.version
 [serialized-collection]: {{DOCS_BASE_URL}}/bonsaidb/core/schema/trait.SerializedCollection.html
 [borrowed-document]: {{DOCS_BASE_URL}}/bonsaidb/core/document/trait.Document.html

--- a/crates/bonsaidb-client/src/client/quic_worker.rs
+++ b/crates/bonsaidb-client/src/client/quic_worker.rs
@@ -29,7 +29,7 @@ pub async fn reconnecting_client_loop(
     connection_counter: Arc<AtomicU32>,
 ) -> Result<(), Error> {
     if url.port().is_none() && url.scheme() == "bonsaidb" {
-        let _ = url.set_port(Some(5645));
+        let _: Result<_, _> = url.set_port(Some(5645));
     }
 
     subscribers.clear();

--- a/crates/bonsaidb-client/src/client/sync.rs
+++ b/crates/bonsaidb-client/src/client/sync.rs
@@ -652,14 +652,14 @@ impl Tokio {
                 let (completion_sender, completion_receiver) = oneshot::channel();
                 let task = async move {
                     task.await?;
-                    let _ = completion_sender.send(());
+                    let _: Result<_, _> = completion_sender.send(());
                     Ok(())
                 };
                 let task = tokio.spawn(task);
 
                 std::thread::spawn(move || {
                     tokio.block_on(async move {
-                        let _ = completion_receiver.await;
+                        let _: Result<_, _> = completion_receiver.await;
                     });
                 });
                 task

--- a/crates/bonsaidb-client/src/client/wasm_websocket_worker.rs
+++ b/crates/bonsaidb-client/src/client/wasm_websocket_worker.rs
@@ -242,7 +242,7 @@ fn on_error_callback(
 ) -> JsValue {
     Closure::once_into_js(move |e: ErrorEvent| {
         ws.set_onerror(None);
-        let _ = shutdown.send(());
+        let _: Result<_, _> = shutdown.send(());
         if let Some(initial_request) = take_initial_request(&initial_request) {
             drop(
                 initial_request
@@ -281,7 +281,7 @@ fn on_close_callback(
     connection_counter: Arc<AtomicU32>,
 ) -> JsValue {
     Closure::once_into_js(move |c: CloseEvent| {
-        let _ = shutdown.send(());
+        let _: Result<_, _> = shutdown.send(());
         ws.set_onclose(None);
 
         let mut pending_error = Some(Error::from(WebSocketError(format!(

--- a/crates/bonsaidb-core/src/connection.rs
+++ b/crates/bonsaidb-core/src/connection.rs
@@ -609,22 +609,21 @@ where
 /// use bonsaidb_core::define_basic_unique_mapped_view;
 /// use bonsaidb_core::document::{CollectionDocument, Emit};
 /// use bonsaidb_core::schema::{
-///     CollectionViewSchema, DefaultViewSerialization, Name, ReduceResult, View, ViewMapResult,
-///     ViewMappedValue,
+///     CollectionMapReduce, DefaultViewSerialization, Name, ReduceResult, View, ViewMapResult,
+///     ViewMappedValue, ViewSchema,
 /// };
 ///
-/// #[derive(Debug, Clone, View)]
+/// #[derive(Debug, Clone, View, ViewSchema)]
 /// #[view(collection = MyCollection, key = u32, value = f32, name = "scores-by-rank")]
 /// # #[view(core = bonsaidb_core)]
+/// # #[view_schema(core = bonsaidb_core)]
 /// pub struct ScoresByRank;
 ///
-/// impl CollectionViewSchema for ScoresByRank {
-///     type View = Self;
-///
-///     fn map(
+/// impl CollectionMapReduce for ScoresByRank {
+///     fn map<'doc>(
 ///         &self,
 ///         document: CollectionDocument<<Self::View as View>::Collection>,
-///     ) -> ViewMapResult<Self::View> {
+///     ) -> ViewMapResult<'doc, Self::View> {
 ///         document
 ///             .header
 ///             .emit_key_and_value(document.contents.rank, document.contents.score)
@@ -632,7 +631,7 @@ where
 ///
 ///     fn reduce(
 ///         &self,
-///         mappings: &[ViewMappedValue<Self::View>],
+///         mappings: &[ViewMappedValue<'_, Self::View>],
 ///         rereduce: bool,
 ///     ) -> ReduceResult<Self::View> {
 ///         if mappings.is_empty() {
@@ -1789,22 +1788,21 @@ where
 /// use bonsaidb_core::define_basic_unique_mapped_view;
 /// use bonsaidb_core::document::{CollectionDocument, Emit};
 /// use bonsaidb_core::schema::{
-///     CollectionViewSchema, DefaultViewSerialization, Name, ReduceResult, View, ViewMapResult,
-///     ViewMappedValue,
+///     CollectionMapReduce, DefaultViewSerialization, Name, ReduceResult, View, ViewMapResult,
+///     ViewMappedValue, ViewSchema,
 /// };
 ///
-/// #[derive(Debug, Clone, View)]
+/// #[derive(Debug, Clone, View, ViewSchema)]
 /// #[view(collection = MyCollection, key = u32, value = f32, name = "scores-by-rank")]
 /// # #[view(core = bonsaidb_core)]
+/// # #[view_schema(core = bonsaidb_core)]
 /// pub struct ScoresByRank;
 ///
-/// impl CollectionViewSchema for ScoresByRank {
-///     type View = Self;
-///
-///     fn map(
+/// impl CollectionMapReduce for ScoresByRank {
+///     fn map<'doc>(
 ///         &self,
 ///         document: CollectionDocument<<Self::View as View>::Collection>,
-///     ) -> ViewMapResult<Self::View> {
+///     ) -> ViewMapResult<'doc, Self::View> {
 ///         document
 ///             .header
 ///             .emit_key_and_value(document.contents.rank, document.contents.score)
@@ -1812,7 +1810,7 @@ where
 ///
 ///     fn reduce(
 ///         &self,
-///         mappings: &[ViewMappedValue<Self::View>],
+///         mappings: &[ViewMappedValue<'_, Self::View>],
 ///         rereduce: bool,
 ///     ) -> ReduceResult<Self::View> {
 ///         if mappings.is_empty() {
@@ -3544,9 +3542,9 @@ macro_rules! __doctest_prelude {
             define_basic_unique_mapped_view,
             document::{CollectionDocument,Emit, Document, OwnedDocument},
             schema::{
-                Collection, CollectionName, CollectionViewSchema, DefaultSerialization,
+                Collection, CollectionName,  DefaultSerialization,
                 DefaultViewSerialization, Name, NamedCollection, ReduceResult, Schema, SchemaName,
-                Schematic, SerializedCollection, View, ViewMapResult, ViewMappedValue, SerializedView,
+                Schematic, SerializedCollection, View, ViewSchema, CollectionMapReduce, ViewMapResult, ViewMappedValue, SerializedView,
             },
             Error,
         };
@@ -3582,16 +3580,16 @@ macro_rules! __doctest_prelude {
             type ByNameView = MyCollectionByName;
         }
 
-        #[derive(Debug, Clone, View)]
+        #[derive(Debug, Clone, View, ViewSchema)]
         #[view(collection = MyCollection, key = u32, value = f32, name = "scores-by-rank", core = $crate)]
+        #[view_schema(core = $crate)]
         pub struct ScoresByRank;
 
-        impl CollectionViewSchema for ScoresByRank {
-            type View = Self;
-            fn map(
+        impl CollectionMapReduce for ScoresByRank {
+            fn map<'doc>(
                 &self,
                 document: CollectionDocument<<Self::View as View>::Collection>,
-            ) -> ViewMapResult<Self::View> {
+            ) -> ViewMapResult<'doc, Self::View> {
                 document
                     .header
                     .emit_key_and_value(document.contents.rank, document.contents.score)
@@ -3599,7 +3597,7 @@ macro_rules! __doctest_prelude {
 
             fn reduce(
                 &self,
-                mappings: &[ViewMappedValue<Self::View>],
+                mappings: &[ViewMappedValue<'_, Self::View>],
                 rereduce: bool,
             ) -> ReduceResult<Self::View> {
                 if mappings.is_empty() {

--- a/crates/bonsaidb-core/src/schema.rs
+++ b/crates/bonsaidb-core/src/schema.rs
@@ -6,7 +6,7 @@ mod summary;
 pub mod view;
 use std::fmt::Debug;
 
-pub use bonsaidb_macros::{Collection, Schema, View};
+pub use bonsaidb_macros::{Collection, Schema, View, ViewSchema};
 
 pub use self::collection::{
     AsyncEntry, AsyncList, Collection, DefaultSerialization, InsertError, List, Nameable,
@@ -20,7 +20,7 @@ pub use self::schematic::Schematic;
 pub use self::summary::{CollectionSummary, SchemaSummary, ViewSummary};
 pub use self::view::map::{Map, MappedValue, ViewMappedValue};
 pub use self::view::{
-    CollectionViewSchema, DefaultViewSerialization, ReduceResult, SerializedView, View,
+    CollectionMapReduce, DefaultViewSerialization, MapReduce, ReduceResult, SerializedView, View,
     ViewMapResult, ViewSchema,
 };
 use crate::Error;

--- a/crates/bonsaidb-core/src/schema/collection.rs
+++ b/crates/bonsaidb-core/src/schema/collection.rs
@@ -54,7 +54,7 @@ use crate::Error;
 /// The list of views can be specified using the `views` parameter:
 ///
 /// ```rust
-/// use bonsaidb_core::schema::{Collection, View};
+/// use bonsaidb_core::schema::{Collection, View, ViewSchema};
 /// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Debug, Serialize, Deserialize, Default, Collection)]
@@ -62,30 +62,30 @@ use crate::Error;
 /// # #[collection(core = bonsaidb_core)]
 /// pub struct MyCollection;
 ///
-/// #[derive(Debug, Clone, View)]
+/// #[derive(Debug, Clone, View, ViewSchema)]
 /// #[view(collection = MyCollection, key = u32, value = f32, name = "scores-by-rank")]
 /// # #[view(core = bonsaidb_core)]
+/// # #[view_schema(core = bonsaidb_core)]
 /// pub struct ScoresByRank;
 /// #
 /// # use bonsaidb_core::{
 /// #     document::CollectionDocument,
 /// #     schema::{
-/// #         CollectionViewSchema,   ReduceResult,
+/// #         ReduceResult, CollectionMapReduce,
 /// #         ViewMapResult, ViewMappedValue,
 /// #    },
 /// # };
-/// # impl CollectionViewSchema for ScoresByRank {
-/// #     type View = Self;
-/// #     fn map(
+/// # impl CollectionMapReduce for ScoresByRank {
+/// #     fn map<'doc>(
 /// #         &self,
 /// #         _document: CollectionDocument<<Self::View as View>::Collection>,
-/// #     ) -> ViewMapResult<Self::View> {
+/// #     ) -> ViewMapResult<'doc, Self::View> {
 /// #         todo!()
 /// #     }
 /// #
 /// #     fn reduce(
 /// #         &self,
-/// #         _mappings: &[ViewMappedValue<Self::View>],
+/// #         _mappings: &[ViewMappedValue<'_, Self::View>],
 /// #         _rereduce: bool,
 /// #     ) -> ReduceResult<Self::View> {
 /// #         todo!()

--- a/crates/bonsaidb-core/src/schema/schematic.rs
+++ b/crates/bonsaidb-core/src/schema/schematic.rs
@@ -9,7 +9,7 @@ use crate::document::{BorrowedDocument, DocumentId, KeyId};
 use crate::key::{ByteSource, Key, KeyDescription};
 use crate::schema::collection::Collection;
 use crate::schema::view::map::{self, MappedValue};
-use crate::schema::view::{self, Serialized, SerializedView, ViewSchema};
+use crate::schema::view::{self, MapReduce, Serialized, SerializedView, ViewSchema};
 use crate::schema::{CollectionName, Schema, SchemaName, View, ViewName};
 use crate::Error;
 
@@ -66,7 +66,7 @@ impl Schematic {
     }
 
     /// Adds the view `V`.
-    pub fn define_view<V: ViewSchema<View = V> + SerializedView + Clone + 'static>(
+    pub fn define_view<V: MapReduce + ViewSchema<View = V> + SerializedView + Clone + 'static>(
         &mut self,
         view: V,
     ) -> Result<(), Error> {
@@ -76,7 +76,7 @@ impl Schematic {
     /// Adds the view `V`.
     pub fn define_view_with_schema<
         V: SerializedView + 'static,
-        S: ViewSchema<View = V> + 'static,
+        S: MapReduce + ViewSchema<View = V> + 'static,
     >(
         &mut self,
         view: V,
@@ -213,7 +213,7 @@ struct ViewInstance<V, S> {
 impl<V, S> Serialized for ViewInstance<V, S>
 where
     V: SerializedView,
-    S: ViewSchema<View = V>,
+    S: MapReduce + ViewSchema<View = V>,
 {
     fn collection(&self) -> CollectionName {
         <<V as View>::Collection as Collection>::collection_name()

--- a/crates/bonsaidb-core/src/schema/schematic.rs
+++ b/crates/bonsaidb-core/src/schema/schematic.rs
@@ -9,7 +9,9 @@ use crate::document::{BorrowedDocument, DocumentId, KeyId};
 use crate::key::{ByteSource, Key, KeyDescription};
 use crate::schema::collection::Collection;
 use crate::schema::view::map::{self, MappedValue};
-use crate::schema::view::{self, MapReduce, Serialized, SerializedView, ViewSchema};
+use crate::schema::view::{
+    self, MapReduce, Serialized, SerializedView, ViewSchema, ViewUpdatePolicy,
+};
 use crate::schema::{CollectionName, Schema, SchemaName, View, ViewName};
 use crate::Error;
 
@@ -89,7 +91,7 @@ impl Schematic {
         }
 
         let collection = instance.collection();
-        let eager = instance.eager();
+        let eager = instance.update_policy().is_eager();
         self.views.insert(TypeId::of::<V>(), Box::new(instance));
         self.views_by_name.insert(name, TypeId::of::<V>());
 
@@ -223,12 +225,8 @@ where
         KeyDescription::for_key::<<V as View>::Key>()
     }
 
-    fn unique(&self) -> bool {
-        self.schema.unique()
-    }
-
-    fn lazy(&self) -> bool {
-        self.schema.lazy()
+    fn update_policy(&self) -> ViewUpdatePolicy {
+        self.schema.update_policy()
     }
 
     fn version(&self) -> u64 {

--- a/crates/bonsaidb-core/src/schema/summary.rs
+++ b/crates/bonsaidb-core/src/schema/summary.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::key::KeyDescription;
+use crate::schema::view::ViewUpdatePolicy;
 use crate::schema::{CollectionName, SchemaName, Schematic, ViewName};
 
 /// A summary of a [`Schema`](crate::schema::Schema)/[`Schematic`].
@@ -57,8 +58,7 @@ impl<'a> From<&'a Schematic> for SchemaSummary {
                     ViewSummary {
                         name,
                         key: view.key_description(),
-                        lazy: view.lazy(),
-                        unique: view.unique(),
+                        policy: view.update_policy(),
                         version: view.version(),
                     },
                 );
@@ -100,13 +100,12 @@ pub struct ViewSummary {
     pub name: ViewName,
     /// The description of [`View::Key`](crate::schema::View::Key).
     pub key: KeyDescription,
-    /// The result of [`ViewSchema::lazy()`](crate::schema::ViewSchema::lazy)
-    /// for this view.
-    pub lazy: bool,
-    /// The result of [`ViewSchema::unique()`](crate::schema::ViewSchema::unique)
-    /// for this view.
-    pub unique: bool,
-    /// The result of [`ViewSchema::version()`](crate::schema::ViewSchema::version)
-    /// for this view.
+    /// The result of
+    /// [`ViewSchema::policy()`](crate::schema::ViewSchema::policy) for this
+    /// view.
+    pub policy: ViewUpdatePolicy,
+    /// The result of
+    /// [`ViewSchema::version()`](crate::schema::ViewSchema::version) for this
+    /// view.
     pub version: u64,
 }

--- a/crates/bonsaidb-core/src/schema/view.rs
+++ b/crates/bonsaidb-core/src/schema/view.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use transmog::{Format, OwnedDeserializer};
 use transmog_pot::Pot;
 
@@ -54,12 +54,17 @@ pub type ReduceResult<V> = Result<<V as View>::Value, crate::Error>;
 ///
 /// A view provides an efficient way to query data within a collection. BonsaiDb
 /// indexes the associated [`View::Collection`] by calling
-/// [`CollectionViewSchema::map()`]/[`ViewSchema::map()`] every time a document
-/// is created or updated. The result [`Mappings`] form a sorted index that can
-/// be efficiently queried using the [`View::Key`] type.
+/// [`CollectionMapReduce::map()`]/[`MapReduce::map()`] every time a document is
+/// created or updated. The result [`Mappings`] form a sorted index that can be
+/// efficiently queried using the [`View::Key`] type.
 ///
 /// A View behaves similarly to the standard library's BTreeMap with these
 /// types: `BTreeMap<View::Key, Vec<(Header, View::Value)>>`
+///
+/// This trait only defines the types and functionality required to interact
+/// with the view's query system. The [`MapReduce`]/[`CollectionMapReduce`]
+/// traits define the map/reduce behavior, and the [`ViewSchema`] trait defines
+/// additional metadata such as the [`ViewUpdatePolicy`] and view version.
 ///
 /// For a deeper dive on Views, see [the section in our user's
 /// guide](https://dev.bonsaidb.io/main/guide/about/concepts/view.html).
@@ -85,7 +90,83 @@ pub trait View: Sized + Send + Sync + Debug + 'static {
     }
 }
 
-/// The implementation of Map/Reduce for a [`View`].
+/// Schema information for a [`View`].
+///
+/// This trait controls several behaviors for a view:
+///
+/// - [`MappedKey<'doc>`](Self::MappedKey): A [`Key`] type that is compatible
+///   with the associated [`View::Key`] type, but can borrow from the document
+///   by using the `'doc` generic associated lifetime.
+/// - [`policy()`](Self::policy): Controls when the view's data is updated and
+///   any restrictions on the data contained in the view. The default policy for
+///   views is [`ViewUpdatePolicy`]
+/// - [`version()`](Self::version): An integer representing the view's version.
+///   Changing this number will cause the view to be re-indexed. This is useful
+///   when there are fundamental changes in how the view is implemented.
+///
+/// ## Where is this trait used?
+///
+/// This trait is currently only used by `bonsaidb-local`, but is provided in
+/// `bonsaidb-core` to allow it to be used anywhere. It may be desireable to
+/// keep the implementation of `ViewSchema` in the "server" binary, while only
+/// exposing the `View` implementation to the "client".
+///
+/// ## Deriving this Trait
+///
+/// This trait can be derived, and all attributes are optional. The available
+/// options are:
+///
+/// - `view`: Sets the associated [`View`](Self::View) type. If not provided,
+///   `Self` will be used.
+/// - `version`: Sets the [version number](Self::version) of the view. If not
+///   provided, `0` will be used.
+/// - `mapped_key`: Sets the [`MappedKey<'doc>`](Self::MappedKey) type to the
+///   provided type. The `'doc` lifetime can be utilized to borrow data during
+///   the [`MapReduce::map()`] function.
+///
+///   If not provided, the `ViewSchema` implementation uses [`View::Key`].
+/// - `policy`: Sets the [`ViewUpdatePolicy`]. The accepted policies are:
+///   - [`Lazy`](ViewUpdatePolicy::Lazy)
+///   - [`Eager`](ViewUpdatePolicy::Eager)
+///   - [`Unique`](ViewUpdatePolicy::Unique)
+///
+///   If not provided, the [`Lazy`](ViewUpdatePolicy::Lazy) policy will be used.
+///
+/// Here is an example that showcases most of the options:
+/// ```rust
+/// # mod collection {
+/// # bonsaidb_core::__doctest_prelude!();
+/// # }
+/// # use collection::MyCollection;
+/// use std::borrow::Cow;
+///
+/// use bonsaidb_core::document::{BorrowedDocument, Emit};
+/// use bonsaidb_core::schema::view::{ReduceResult, ViewMapResult};
+/// use bonsaidb_core::schema::{MapReduce, View, ViewMappedValue, ViewSchema};
+///
+/// #[derive(View, ViewSchema, Debug)]
+/// #[view(collection = MyCollection, key = String, value = u32)]
+/// #[view_schema(mapped_key = Cow<'doc, str>, policy = Unique)]
+/// # #[view(core = bonsaidb_core)]
+/// struct UniqueByName;
+///
+/// impl MapReduce for UniqueByName {
+///     fn map<'doc>(&self, document: &'doc BorrowedDocument<'_>) -> ViewMapResult<'doc, Self> {
+///         let contents_as_str = std::str::from_utf8(&document.contents).expect("invalid utf-8");
+///         document
+///             .header
+///             .emit_key_and_value(Cow::Borrowed(contents_as_str), 1)
+///     }
+///
+///     fn reduce(
+///         &self,
+///         mappings: &[ViewMappedValue<'_, Self::View>],
+///         _rereduce: bool,
+///     ) -> ReduceResult<Self::View> {
+///         Ok(mappings.iter().map(|mapping| mapping.value).sum())
+///     }
+/// }
+/// ```
 #[doc = "\n"]
 #[doc = include_str!("./view-overview.md")]
 pub trait ViewSchema: Send + Sync + Debug + 'static {
@@ -102,27 +183,54 @@ pub trait ViewSchema: Send + Sync + Debug + 'static {
     /// borrowed from the document.
     type MappedKey<'doc>: Key<'doc>;
 
-    /// If true, no two documents may emit the same key. Unique views are
-    /// updated when the document is saved, allowing for this check to be done
-    /// atomically. When a document is updated, all unique views will be
-    /// updated, and if any of them fail, the document will not be allowed to
-    /// update and an
-    /// [`Error::UniqueKeyViolation`](crate::Error::UniqueKeyViolation) will be
-    /// returned.
-    fn unique(&self) -> bool {
-        false
+    /// Returns the update policy for this view, which controls when and how the
+    /// view's data is updated. The provided implementation returns
+    /// [`ViewUpdatePolicy::Lazy`].
+    fn update_policy(&self) -> ViewUpdatePolicy {
+        ViewUpdatePolicy::default()
     }
 
-    /// Returns whether this view should be lazily updated. If true, views will
-    /// be updated only when accessed. If false, views will be updated during
-    /// the transaction that is updating the affected documents.
-    fn lazy(&self) -> bool {
-        true
-    }
-
-    /// The version of the view. Changing this value will cause indexes to be rebuilt.
+    /// The version of the view. Changing this value will cause indexes to be
+    /// rebuilt.
     fn version(&self) -> u64 {
         0
+    }
+}
+
+/// The policy under which a [`View`] is updated when documents are saved.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ViewUpdatePolicy {
+    /// The view is updated when a query is made. If a document is updated
+    /// multiple times between queries, the view will only be updated when the
+    /// query is executed.
+    #[default]
+    Lazy,
+    /// The view is updated during the transaction where documents are being
+    /// inserted, updated, or removed.
+    Eager,
+    /// No two documents may emit the same key. Unique views are updated when
+    /// the document is saved, allowing for this check to be done atomically.
+    /// When a document is updated, all unique views will be updated, and if any
+    /// of them fail, the document will not be allowed to update and an
+    /// [`Error::UniqueKeyViolation`](crate::Error::UniqueKeyViolation) will be
+    /// returned.
+    Unique,
+}
+
+impl ViewUpdatePolicy {
+    /// Returns true if the view should be updated eagerly.
+    ///
+    /// This returns true if the policy is either [`Eager`](Self::Eager) or
+    /// [`Unique`](Self::Unique).
+    #[must_use]
+    pub const fn is_eager(&self) -> bool {
+        matches!(self, Self::Eager | Self::Unique)
+    }
+}
+
+impl std::fmt::Display for ViewUpdatePolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self, f)
     }
 }
 
@@ -244,28 +352,6 @@ where
     }
 }
 
-// impl<T> ViewSchema for T
-// where
-//     T: CollectionViewSchema,
-//     T::View: SerializedView,
-//     <T::View as View>::Collection: SerializedCollection,
-// {
-//     type MappedKey<'doc> = <T::View as View>::Key;
-//     type View = T::View;
-
-//     fn version(&self) -> u64 {
-//         T::version(self)
-//     }
-
-//     fn unique(&self) -> bool {
-//         T::unique(self)
-//     }
-
-//     fn lazy(&self) -> bool {
-//         T::lazy(self)
-//     }
-// }
-
 impl<T> MapReduce for T
 where
     T: CollectionMapReduce,
@@ -291,16 +377,8 @@ pub trait Serialized: Send + Sync + Debug {
     fn collection(&self) -> CollectionName;
     /// Returns the description of the view's `Key`.
     fn key_description(&self) -> KeyDescription;
-    /// Wraps [`ViewSchema::unique`]
-    fn unique(&self) -> bool;
-    /// Wraps [`ViewSchema::lazy`]
-    fn lazy(&self) -> bool;
-
-    /// Returns true if this view should be eagerly updated during document
-    /// updates.
-    fn eager(&self) -> bool {
-        self.unique() || !self.lazy()
-    }
+    /// Wraps [`ViewSchema::policy`]
+    fn update_policy(&self) -> ViewUpdatePolicy;
 
     /// Wraps [`ViewSchema::version`]
     fn version(&self) -> u64;
@@ -393,8 +471,12 @@ macro_rules! define_mapped_view {
             type MappedKey<'doc> = <Self as $crate::schema::View>::Key;
             type View = Self;
 
-            fn unique(&self) -> bool {
-                $unique
+            fn update_policy(&self) -> $crate::schema::view::ViewUpdatePolicy {
+                if $unique {
+                    $crate::schema::view::ViewUpdatePolicy::Unique
+                } else {
+                    $crate::schema::view::ViewUpdatePolicy::Lazy
+                }
             }
 
             fn version(&self) -> u64 {

--- a/crates/bonsaidb-core/src/test_util.rs
+++ b/crates/bonsaidb-core/src/test_util.rs
@@ -23,7 +23,7 @@ use crate::document::{
 use crate::keyvalue::{AsyncKeyValue, KeyValue};
 use crate::limits::{LIST_TRANSACTIONS_DEFAULT_RESULT_COUNT, LIST_TRANSACTIONS_MAX_RESULTS};
 use crate::schema::view::map::{Mappings, ViewMappedValue};
-use crate::schema::view::{MapReduce, ReduceResult, SerializedView};
+use crate::schema::view::{MapReduce, ReduceResult, SerializedView, ViewUpdatePolicy};
 use crate::schema::{
     Collection, CollectionName, MappedValue, NamedCollection, Qualified, Schema, SchemaName,
     Schematic, SerializedCollection, View, ViewMapResult, ViewSchema,
@@ -123,7 +123,7 @@ impl MapReduce for BasicByParentId {
 
 #[derive(Debug, Clone, View, ViewSchema)]
 #[view(collection = Basic, key = Option<u64>, value = usize, name = "by-parent-id-eager", core = crate)]
-#[view_schema(core = crate, version = 1, lazy = false)]
+#[view_schema(core = crate, version = 1, policy = Eager)]
 pub struct BasicByParentIdEager;
 
 impl MapReduce for BasicByParentIdEager {
@@ -353,7 +353,7 @@ impl Unique {
 
 #[derive(Debug, Clone, View, ViewSchema)]
 #[view(collection = Unique, key = String, value = (), name = "unique-value", core = crate)]
-#[view_schema(core = crate, unique = true)]
+#[view_schema(core = crate, policy = Unique)]
 pub struct UniqueValue;
 
 impl MapReduce for UniqueValue {
@@ -3865,8 +3865,7 @@ pub async fn basic_server_connection_tests<C: AsyncStorageConnection>(
         .views()
         .any(|v| v.name == BasicByParentId.view_name()));
     let by_parent_id = basic_collection.view(&BasicByParentId.view_name()).unwrap();
-    assert!(!by_parent_id.unique);
-    assert!(by_parent_id.lazy);
+    assert_eq!(by_parent_id.policy, ViewUpdatePolicy::Lazy);
 
     assert!(schemas
         .iter()
@@ -3929,8 +3928,7 @@ pub fn blocking_basic_server_connection_tests<C: StorageConnection>(
         .views()
         .any(|v| v.name == BasicByParentId.view_name()));
     let by_parent_id = basic_collection.view(&BasicByParentId.view_name()).unwrap();
-    assert!(!by_parent_id.unique);
-    assert!(by_parent_id.lazy);
+    assert_eq!(by_parent_id.policy, ViewUpdatePolicy::Lazy);
 
     assert!(schemas
         .iter()

--- a/crates/bonsaidb-files/src/schema/file.rs
+++ b/crates/bonsaidb-files/src/schema/file.rs
@@ -383,7 +383,7 @@ impl<Config> DefaultSerialization for File<Config> where Config: FileConfig {}
 #[derive(View, ViewSchema)]
 #[view(name = "by-path", collection = File<Config>, key = OwnedFileKey, value = (TimestampAsNanoseconds, Config::Metadata))]
 #[view(core = bonsaidb_core)]
-#[view_schema(version = 3, unique = true, core = bonsaidb_core)]
+#[view_schema(version = 3, policy = Unique, core = bonsaidb_core)]
 pub struct ByPath<Config>(PhantomData<Config>)
 where
     Config: FileConfig;

--- a/crates/bonsaidb-files/src/schema/file.rs
+++ b/crates/bonsaidb-files/src/schema/file.rs
@@ -11,10 +11,11 @@ use bonsaidb_core::key::{
     IntoPrefixRange, Key, KeyEncoding, KeyKind,
 };
 use bonsaidb_core::schema::{
-    Collection, CollectionName, CollectionViewSchema, DefaultSerialization, SerializedCollection,
+    Collection, CollectionMapReduce, CollectionName, DefaultSerialization, SerializedCollection,
     View, ViewMapResult,
 };
 use bonsaidb_core::transaction::{Operation, Transaction};
+use bonsaidb_macros::ViewSchema;
 use bonsaidb_utils::next_string_sequence;
 use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
@@ -379,28 +380,19 @@ where
 impl<Config> DefaultSerialization for File<Config> where Config: FileConfig {}
 
 #[derive_where(Clone, Debug, Default)]
-#[derive(View)]
+#[derive(View, ViewSchema)]
 #[view(name = "by-path", collection = File<Config>, key = OwnedFileKey, value = (TimestampAsNanoseconds, Config::Metadata))]
 #[view(core = bonsaidb_core)]
+#[view_schema(version = 3, unique = true, core = bonsaidb_core)]
 pub struct ByPath<Config>(PhantomData<Config>)
 where
     Config: FileConfig;
 
-impl<Config> CollectionViewSchema for ByPath<Config>
+impl<Config> CollectionMapReduce for ByPath<Config>
 where
     Config: FileConfig,
 {
-    type View = Self;
-
-    fn version(&self) -> u64 {
-        3
-    }
-
-    fn unique(&self) -> bool {
-        true
-    }
-
-    fn map(&self, doc: CollectionDocument<File<Config>>) -> ViewMapResult<'static, Self> {
+    fn map<'doc>(&self, doc: CollectionDocument<File<Config>>) -> ViewMapResult<'doc, Self> {
         doc.header.emit_key_and_value(
             OwnedFileKey(FileKey::Full {
                 path: Cow::Owned(doc.contents.path.unwrap_or_else(|| String::from("/"))),

--- a/crates/bonsaidb-local/src/cli/schema.rs
+++ b/crates/bonsaidb-local/src/cli/schema.rs
@@ -45,8 +45,7 @@ impl Command {
                         let Some(view) = collection.view(&view)
                                 else { return Err(crate::Error::Core(bonsaidb_core::Error::ViewNotFound))};
                         println!("Version: {}", view.version);
-                        println!("Lazy: {}", view.lazy);
-                        println!("Unique: {}", view.unique);
+                        println!("Policy: {}", view.policy);
                     }
                     CollectionOrView::Collection(collection) => {
                         let Some(collection) = schema.collection(&collection)

--- a/crates/bonsaidb-local/src/database.rs
+++ b/crates/bonsaidb-local/src/database.rs
@@ -393,7 +393,7 @@ impl Database {
                 .data
                 .schema
                 .views_in_collection(collection)
-                .filter(|view| !view.eager())
+                .filter(|view| !view.update_policy().is_eager())
                 .peekable();
             if views.peek().is_some() {
                 let changed_documents = changed_documents.collect::<Vec<_>>();

--- a/crates/bonsaidb-local/src/database.rs
+++ b/crates/bonsaidb-local/src/database.rs
@@ -1737,7 +1737,7 @@ impl Drop for ContextData {
             let mut state = self.key_value_state.lock();
             state.shutdown(&self.key_value_state)
         } {
-            let _ = shutdown.recv();
+            let _: Result<_, _> = shutdown.recv();
         }
     }
 }

--- a/crates/bonsaidb-local/src/database/keyvalue.rs
+++ b/crates/bonsaidb-local/src/database/keyvalue.rs
@@ -615,15 +615,15 @@ impl KeyValueState {
             (Some(commit_target), Some(key_target)) => {
                 let closest_target = key_target.min(commit_target);
                 let new_target = BackgroundWorkerProcessTarget::Timestamp(closest_target);
-                let _ = self.background_worker_target.update(new_target);
+                let _: Result<_, _> = self.background_worker_target.update(new_target);
             }
             (Some(target), None) | (None, Some(target)) => {
-                let _ = self
+                let _: Result<_, _> = self
                     .background_worker_target
                     .update(BackgroundWorkerProcessTarget::Timestamp(target));
             }
             (None, None) => {
-                let _ = self
+                let _: Result<_, _> = self
                     .background_worker_target
                     .update(BackgroundWorkerProcessTarget::Never);
             }
@@ -750,7 +750,7 @@ impl KeyValueState {
                 let staged_keys = state.stage_dirty_keys();
                 if staged_keys.is_none() {
                     let shutdown = state.shutdown.take().unwrap();
-                    let _ = shutdown.send(());
+                    let _: Result<_, _> = shutdown.send(());
                 }
                 staged_keys
             } else {

--- a/crates/bonsaidb-local/src/open_trees.rs
+++ b/crates/bonsaidb-local/src/open_trees.rs
@@ -54,7 +54,7 @@ impl OpenTrees {
 
         for view in schema.views_in_collection(collection) {
             let view_name = view.view_name();
-            if view.eager() {
+            if view.update_policy().is_eager() {
                 self.open_tree::<Unversioned>(
                     &view_document_map_tree_name(&view_name),
                     #[cfg(any(feature = "encryption", feature = "compression"))]

--- a/crates/bonsaidb-local/src/tests/compatibility.rs
+++ b/crates/bonsaidb-local/src/tests/compatibility.rs
@@ -32,7 +32,7 @@ struct Unique {
 
 #[derive(View, Debug, Clone, ViewSchema)]
 #[view(collection = Unique, key = String, core = bonsaidb_core)]
-#[view_schema(core = bonsaidb_core, unique = true)]
+#[view_schema(core = bonsaidb_core, policy = Unique)]
 struct UniqueView;
 
 impl CollectionMapReduce for UniqueView {

--- a/crates/bonsaidb-local/src/views/mapper.rs
+++ b/crates/bonsaidb-local/src/views/mapper.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use bonsaidb_core::arc_bytes::serde::Bytes;
 use bonsaidb_core::arc_bytes::{ArcBytes, OwnedBytes};
 use bonsaidb_core::connection::Connection;
-use bonsaidb_core::schema::view::{self, map, Serialized};
+use bonsaidb_core::schema::view::{self, map, Serialized, ViewUpdatePolicy};
 use bonsaidb_core::schema::{CollectionName, ViewName};
 use easy_parallel::Parallel;
 use nebari::io::any::AnyFile;
@@ -465,7 +465,7 @@ impl<'a> ViewEntryUpdater<'a> {
         if let Some(new_mappings) = self.new_mappings.remove(&key[..]) {
             for map::Serialized { source, value, .. } in new_mappings {
                 // Before altering any data, verify that the key is unique if this is a unique view.
-                if self.view.unique()
+                if self.view.update_policy() == ViewUpdatePolicy::Unique
                     && !view_entry.mappings.is_empty()
                     && view_entry.mappings[0].source.id != source.id
                 {

--- a/crates/bonsaidb-macros/src/lib.rs
+++ b/crates/bonsaidb-macros/src/lib.rs
@@ -20,11 +20,12 @@ use quote_use::{
     format_ident_namespaced as format_ident, parse_quote_use as parse_quote, quote_use as quote,
 };
 use syn::punctuated::Punctuated;
-use syn::token::Paren;
 use syn::{
     parse_macro_input, Data, DataEnum, DataStruct, DeriveInput, Expr, Field, Fields, FieldsNamed,
-    FieldsUnnamed, Ident, Index, LitStr, Path, Token, Type, TypePath, TypeTuple, Variant,
+    FieldsUnnamed, Ident, Index, Path, Token, Type, TypePath, Variant,
 };
+
+mod view;
 
 // -----------------------------------------------------------------------------
 //     - Core Macros -
@@ -68,6 +69,7 @@ macro_rules! unwrap_or_abort {
         }
     };
 }
+pub(crate) use unwrap_or_abort;
 
 #[derive(Attribute)]
 #[attribute(ident = collection)]
@@ -215,91 +217,22 @@ pub fn collection_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
     }
     .into()
 }
-
-#[derive(Attribute)]
-#[attribute(ident = view)]
-struct ViewAttribute {
-    #[attribute(example = "CollectionType")]
-    #[attribute(example = "CollectionType")]
-    collection: Type,
-    #[attribute(example = "KeyType")]
-    key: Type,
-    #[attribute(example = "\"by-name\"")]
-    name: Option<LitStr>,
-    #[attribute(example = "ValueType")]
-    value: Option<Type>,
-    #[attribute(example = "bosaidb::core")]
-    core: Option<Path>,
-    #[attribute(example = "Format or None")]
-    serialization: Option<Path>,
-}
-
 /// Derives the `bonsaidb::core::schema::View` trait.
 #[proc_macro_error]
 /// `#[view(collection=CollectionType, key=KeyType, value=ValueType, name = "by-name")]`
 /// `name` and `value` are optional
 #[proc_macro_derive(View, attributes(view))]
 pub fn view_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let DeriveInput {
-        attrs,
-        ident,
-        generics,
-        ..
-    } = parse_macro_input!(input as DeriveInput);
-
-    let ViewAttribute {
-        collection,
-        key,
-        name,
-        value,
-        core,
-        serialization,
-    } = unwrap_or_abort!(ViewAttribute::from_attributes(&attrs));
-
-    let core = core.unwrap_or_else(core_path);
-
-    let value = value.unwrap_or_else(|| {
-        Type::Tuple(TypeTuple {
-            paren_token: Paren::default(),
-            elems: Punctuated::new(),
-        })
-    });
-
-    let name = name
-        .as_ref()
-        .map_or_else(|| ident.to_string(), LitStr::value);
-
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    let serialization = match serialization {
-        Some(serialization) if serialization.is_ident("None") => TokenStream::new(),
-        Some(serialization) => quote! {
-            impl #impl_generics #core::schema::SerializedView for #ident #ty_generics #where_clause {
-                type Format = #serialization;
-
-                fn format() -> Self::Format {
-                    #serialization::default()
-                }
-            }
-        },
-        None => quote! {
-            impl #impl_generics #core::schema::DefaultViewSerialization for #ident #ty_generics #where_clause {}
-        },
-    };
-
-    quote! {
-        impl #impl_generics #core::schema::View for #ident #ty_generics #where_clause {
-            type Collection = #collection;
-            type Key = #key;
-            type Value = #value;
-
-            fn name(&self) -> #core::schema::Name {
-                #core::schema::Name::new(#name)
-            }
-        }
-        #serialization
-    }
-    .into()
+    view::derive(parse_macro_input!(input as DeriveInput)).into()
+}
+/// Derives the `bonsaidb::core::schema::ViewSchema` trait.
+#[proc_macro_error]
+/// `#[view_schema(version = 1, unique = true, lazy = false, view=ViewType, mapped_key=KeyType<'doc>)]`
+///
+/// All attributes are optional.
+#[proc_macro_derive(ViewSchema, attributes(view_schema))]
+pub fn view_schema_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    view::derive_schema(parse_macro_input!(input as DeriveInput)).into()
 }
 
 #[derive(Attribute)]

--- a/crates/bonsaidb-macros/src/view.rs
+++ b/crates/bonsaidb-macros/src/view.rs
@@ -1,0 +1,162 @@
+use attribute_derive::Attribute;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::punctuated::Punctuated;
+use syn::token::Paren;
+use syn::{DeriveInput, LitStr, Path, Type, TypeTuple};
+
+use crate::{core_path, unwrap_or_abort};
+
+#[derive(Attribute)]
+#[attribute(ident = view)]
+struct ViewAttribute {
+    #[attribute(example = "CollectionType")]
+    collection: Type,
+    #[attribute(example = "KeyType")]
+    key: Type,
+    #[attribute(example = "\"by-name\"")]
+    name: Option<LitStr>,
+    #[attribute(example = "ValueType")]
+    value: Option<Type>,
+    #[attribute(example = "bosaidb::core")]
+    core: Option<Path>,
+    #[attribute(example = "Format or None")]
+    serialization: Option<Path>,
+}
+
+pub fn derive(
+    DeriveInput {
+        attrs,
+        ident,
+        generics,
+        ..
+    }: DeriveInput,
+) -> TokenStream {
+    let ViewAttribute {
+        collection,
+        key,
+        name,
+        value,
+        core,
+        serialization,
+    } = unwrap_or_abort!(ViewAttribute::from_attributes(&attrs));
+
+    let core = core.unwrap_or_else(core_path);
+
+    let value = value.unwrap_or_else(|| {
+        Type::Tuple(TypeTuple {
+            paren_token: Paren::default(),
+            elems: Punctuated::new(),
+        })
+    });
+
+    let name = name
+        .as_ref()
+        .map_or_else(|| ident.to_string(), LitStr::value);
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let serialization = match serialization {
+        Some(serialization) if serialization.is_ident("None") => TokenStream::new(),
+        Some(serialization) => quote! {
+            impl #impl_generics #core::schema::SerializedView for #ident #ty_generics #where_clause {
+                type Format = #serialization;
+
+                fn format() -> Self::Format {
+                    #serialization::default()
+                }
+            }
+        },
+        None => quote! {
+            impl #impl_generics #core::schema::DefaultViewSerialization for #ident #ty_generics #where_clause {}
+        },
+    };
+
+    quote! {
+        impl #impl_generics #core::schema::View for #ident #ty_generics #where_clause {
+            type Collection = #collection;
+            type Key = #key;
+            type Value = #value;
+
+            fn name(&self) -> #core::schema::Name {
+                #core::schema::Name::new(#name)
+            }
+        }
+        #serialization
+    }
+}
+
+#[derive(Attribute)]
+#[attribute(ident = view_schema)]
+struct ViewSchemaAttribute {
+    #[attribute(example = "ViewType")]
+    view: Option<Type>,
+    #[attribute(example = "KeyType<'doc>")]
+    mapped_key: Option<Type>,
+    #[attribute(example = "\"by-name\"")]
+    version: Option<u64>,
+    #[attribute(example = "true")]
+    unique: Option<bool>,
+    #[attribute(example = "false")]
+    lazy: Option<bool>,
+    #[attribute(example = "bosaidb::core")]
+    core: Option<Path>,
+}
+
+pub fn derive_schema(
+    DeriveInput {
+        attrs,
+        ident,
+        generics,
+        ..
+    }: DeriveInput,
+) -> TokenStream {
+    let ViewSchemaAttribute {
+        view,
+        mapped_key,
+        version,
+        unique,
+        lazy,
+        core,
+    } = unwrap_or_abort!(ViewSchemaAttribute::from_attributes(&attrs));
+
+    let core = core.unwrap_or_else(core_path);
+
+    let view = view.map_or_else(|| quote!(Self), |ty| quote!(#ty));
+
+    let mapped_key = mapped_key.map_or_else(
+        || quote!(<Self as #core::schema::View>::Key),
+        |ty| quote!(#ty),
+    );
+
+    let version = version.map(|version| {
+        quote!(fn version(&self) -> u64 {
+            #version
+        })
+    });
+
+    let unique = unique.map(|unique| {
+        quote!(fn unique(&self) -> bool {
+            #unique
+        })
+    });
+
+    let lazy = lazy.map(|lazy| {
+        quote!(fn lazy(&self) -> bool {
+            #lazy
+        })
+    });
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics #core::schema::ViewSchema for #ident #ty_generics #where_clause {
+            type View = #view;
+            type MappedKey<'doc> = #mapped_key;
+
+            #version
+            #lazy
+            #unique
+        }
+    }
+}

--- a/crates/bonsaidb-macros/tests/collection.rs
+++ b/crates/bonsaidb-macros/tests/collection.rs
@@ -2,8 +2,8 @@ use core::fmt::Debug;
 
 use bonsaidb::core::document::{CollectionDocument, Emit, KeyId};
 use bonsaidb::core::schema::{
-    Collection, CollectionViewSchema, DefaultSerialization, DefaultViewSerialization, Name,
-    Qualified, Schematic, SerializedCollection, View, ViewMapResult,
+    Collection, CollectionMapReduce, DefaultSerialization, DefaultViewSerialization, Name,
+    Qualified, Schematic, SerializedCollection, View, ViewMapResult, ViewSchema,
 };
 use serde::{Deserialize, Serialize};
 
@@ -57,10 +57,16 @@ fn views() {
         }
     }
 
-    impl CollectionViewSchema for ShapesByNumberOfSides {
+    impl ViewSchema for ShapesByNumberOfSides {
+        type MappedKey<'doc> = u32;
         type View = Self;
+    }
 
-        fn map(&self, document: CollectionDocument<Shape>) -> ViewMapResult<Self::View> {
+    impl CollectionMapReduce for ShapesByNumberOfSides {
+        fn map<'doc>(
+            &self,
+            document: CollectionDocument<Shape>,
+        ) -> ViewMapResult<'doc, Self::View> {
             document
                 .header
                 .emit_key_and_value(document.contents.sides, 1)

--- a/crates/bonsaidb-macros/tests/ui/view_schema/invalid_attribute.rs
+++ b/crates/bonsaidb-macros/tests/ui/view_schema/invalid_attribute.rs
@@ -1,0 +1,7 @@
+use bonsaidb::core::schema::ViewSchema;
+
+#[derive(ViewSchema, Debug)]
+#[view_schema(hi)]
+struct Test1;
+
+fn main() {}

--- a/crates/bonsaidb-macros/tests/ui/view_schema/invalid_attribute.stderr
+++ b/crates/bonsaidb-macros/tests/ui/view_schema/invalid_attribute.stderr
@@ -1,0 +1,5 @@
+error: supported fields are `view`, `mapped_key`, `version`, `policy` and `core`
+ --> tests/ui/view_schema/invalid_attribute.rs:4:15
+  |
+4 | #[view_schema(hi)]
+  |               ^^

--- a/crates/bonsaidb-server/src/server.rs
+++ b/crates/bonsaidb-server/src/server.rs
@@ -800,7 +800,7 @@ impl<B: Backend> CustomServer<B> {
                                 let (shutdown_sender, shutdown_receiver) = flume::bounded(1);
                                 tokio::task::spawn(async move {
                                     task_server.shutdown(Some(Duration::from_secs(30))).await?;
-                                    let _ = shutdown_sender.send(());
+                                    let _: Result<_, _> = shutdown_sender.send(());
                                     Result::<(), Error>::Ok(())
                                 });
                                 *state = SignalShutdownState::ShuttingDown(shutdown_receiver);

--- a/examples/basic-local/examples/keyword-search.rs
+++ b/examples/basic-local/examples/keyword-search.rs
@@ -15,7 +15,8 @@ use std::time::SystemTime;
 
 use bonsaidb::core::document::{CollectionDocument, Emit};
 use bonsaidb::core::schema::{
-    Collection, CollectionViewSchema, SerializedCollection, SerializedView, View, ViewMapResult,
+    Collection, CollectionMapReduce, SerializedCollection, SerializedView, View, ViewMapResult,
+    ViewSchema,
 };
 use bonsaidb::local::config::{Builder, StorageConfiguration};
 use bonsaidb::local::Database;
@@ -40,17 +41,15 @@ impl Message {
     }
 }
 
-#[derive(View, Debug, Clone)]
+#[derive(View, ViewSchema, Debug, Clone)]
 #[view(name = "by-keyword", collection = Message, key = String, value = String)]
 struct MessagesByWords;
 
-impl CollectionViewSchema for MessagesByWords {
-    type View = Self;
-
-    fn map(
+impl CollectionMapReduce for MessagesByWords {
+    fn map<'doc>(
         &self,
         document: CollectionDocument<<Self::View as View>::Collection>,
-    ) -> ViewMapResult<Self::View> {
+    ) -> ViewMapResult<'doc, Self::View> {
         // Emit a key/value mapping for each word found in the subject and body.
         let subject_words =
             keywords(&document.contents.subject).map(|word| (word, String::from("subject")));

--- a/examples/basic-local/examples/view-examples-async.rs
+++ b/examples/basic-local/examples/view-examples-async.rs
@@ -1,8 +1,7 @@
 use bonsaidb::core::document::{CollectionDocument, Emit};
-use bonsaidb::core::schema::view::CollectionViewSchema;
 use bonsaidb::core::schema::{
-    Collection, ReduceResult, SerializedCollection, SerializedView, View, ViewMapResult,
-    ViewMappedValue,
+    Collection, CollectionMapReduce, ReduceResult, SerializedCollection, SerializedView, View,
+    ViewMapResult, ViewMappedValue, ViewSchema,
 };
 use bonsaidb::local::config::{Builder, StorageConfiguration};
 use bonsaidb::local::AsyncDatabase;
@@ -15,14 +14,12 @@ struct Shape {
     pub sides: u32,
 }
 
-#[derive(Debug, Clone, View)]
+#[derive(Debug, Clone, View, ViewSchema)]
 #[view(collection = Shape, key = u32, value = usize, name = "by-number-of-sides")]
 struct ShapesByNumberOfSides;
 
-impl CollectionViewSchema for ShapesByNumberOfSides {
-    type View = Self;
-
-    fn map(&self, document: CollectionDocument<Shape>) -> ViewMapResult<Self::View> {
+impl CollectionMapReduce for ShapesByNumberOfSides {
+    fn map<'doc>(&self, document: CollectionDocument<Shape>) -> ViewMapResult<'doc, Self::View> {
         document
             .header
             .emit_key_and_value(document.contents.sides, 1)

--- a/examples/basic-server/examples/support/schema.rs
+++ b/examples/basic-server/examples/support/schema.rs
@@ -1,6 +1,7 @@
 use bonsaidb::core::document::{CollectionDocument, Emit};
-use bonsaidb::core::schema::view::CollectionViewSchema;
-use bonsaidb::core::schema::{Collection, ReduceResult, View, ViewMapResult, ViewMappedValue};
+use bonsaidb::core::schema::{
+    Collection, CollectionMapReduce, ReduceResult, View, ViewMapResult, ViewMappedValue, ViewSchema,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Collection)]
@@ -15,17 +16,15 @@ impl Shape {
     }
 }
 
-#[derive(Debug, Clone, View)]
+#[derive(Debug, Clone, View, ViewSchema)]
 #[view(collection = Shape, key = u32, value = usize, name = "by-number-of-sides")]
 pub struct ShapesByNumberOfSides;
 
-impl CollectionViewSchema for ShapesByNumberOfSides {
-    type View = Self;
-
-    fn map(
+impl CollectionMapReduce for ShapesByNumberOfSides {
+    fn map<'doc>(
         &self,
         document: CollectionDocument<<Self::View as View>::Collection>,
-    ) -> ViewMapResult<Self::View> {
+    ) -> ViewMapResult<'doc, Self::View> {
         document
             .header
             .emit_key_and_value(document.contents.sides, 1)

--- a/examples/open-library/examples/open-library.rs
+++ b/examples/open-library/examples/open-library.rs
@@ -10,8 +10,8 @@ use bonsaidb::core::connection::{AsyncConnection, AsyncLowLevelConnection};
 use bonsaidb::core::document::{CollectionDocument, Emit};
 use bonsaidb::core::keyvalue::Timestamp;
 use bonsaidb::core::schema::{
-    Collection, CollectionViewSchema, ReduceResult, Schema, SerializedCollection, SerializedView,
-    View, ViewMapResult, ViewMappedValue,
+    Collection, CollectionMapReduce, ReduceResult, Schema, SerializedCollection, SerializedView,
+    View, ViewMapResult, ViewMappedValue, ViewSchema,
 };
 use bonsaidb::core::transaction::{Operation, Transaction};
 use bonsaidb::local::config::{Builder, Compression, StorageConfiguration};
@@ -153,17 +153,15 @@ struct Edition {
     pub last_modified: TypedValue,
 }
 
-#[derive(View, Debug, Clone)]
+#[derive(View, ViewSchema, Debug, Clone)]
 #[view(name = "by-work", collection = Edition, key = String, value = u32)]
 struct EditionsByWork;
 
-impl CollectionViewSchema for EditionsByWork {
-    type View = Self;
-
-    fn map(
+impl CollectionMapReduce for EditionsByWork {
+    fn map<'doc>(
         &self,
         document: CollectionDocument<<Self::View as View>::Collection>,
-    ) -> ViewMapResult<Self::View> {
+    ) -> ViewMapResult<'doc, Self::View> {
         document
             .contents
             .works
@@ -178,7 +176,7 @@ impl CollectionViewSchema for EditionsByWork {
 
     fn reduce(
         &self,
-        mappings: &[ViewMappedValue<Self::View>],
+        mappings: &[ViewMappedValue<'_, Self::View>],
         _rereduce: bool,
     ) -> ReduceResult<Self::View> {
         Ok(mappings.iter().map(|map| map.value).sum())
@@ -242,21 +240,16 @@ struct Work {
     pub last_modified: TypedValue,
 }
 
-#[derive(View, Debug, Clone)]
+#[derive(View, ViewSchema, Debug, Clone)]
 #[view(name = "by-author", collection = Work, key = String, value = u32)]
+#[view_schema(version = 1)]
 struct WorksByAuthor;
 
-impl CollectionViewSchema for WorksByAuthor {
-    type View = Self;
-
-    fn version(&self) -> u64 {
-        1
-    }
-
-    fn map(
+impl CollectionMapReduce for WorksByAuthor {
+    fn map<'doc>(
         &self,
         document: CollectionDocument<<Self::View as View>::Collection>,
-    ) -> ViewMapResult<Self::View> {
+    ) -> ViewMapResult<'doc, Self::View> {
         document
             .contents
             .authors


### PR DESCRIPTION
This PR aims at reducing the complexity introduced in #284. By moving map/reduce to their own trait, it made it easier to provide a derive macro for ViewSchema.

The derive macro is able to substitute in the correct values when no lifetimes are involved, and when the 'doc associated lifetime is used, everything just works as intended.

This also has another nice side effect of simplifying where the magic happens for CollectionDocument-based map/reduce. Now all the shared ViewSchema functionality lives on the shared trait, and CollectionMapReduce is a simplified version of MapReduce when working with SerializedCollections.

Tasks remaining:
- [x] Add UI tests for the new macro
- [x] Add derive documentation to `ViewSchema` docs.
- [x] Document breaking changes.

Most code will be able to be easily updated. For example, here's the  "before"`UniqueView` definition from `core::test_util`:

```rust
#[derive(View, Debug, Clone)]
#[view(collection = Unique, key = String)]
struct UniqueView;

impl CollectionViewSchema for UniqueView {
    type View = UniqueView;

    fn unique(&self) -> bool {
        true
    }

    fn map(
        &self,
        document: CollectionDocument<<Self::View as View>::Collection>,
    ) -> bonsaidb_core::schema::ViewMapResult<'static, Self> {
        document.header.emit_key(document.contents.name)
    }
```

And the updated changes:

```rust
#[derive(View, Debug, Clone, ViewSchema)]
#[view(collection = Unique, key = String)]
#[view_schema(unique = true)]
struct UniqueView;

impl CollectionMapReduce for UniqueView {
    fn map<'doc>(
        &self,
        document: CollectionDocument<<Self::View as View>::Collection>,
    ) -> bonsaidb_core::schema::ViewMapResult<'doc, Self> {
        document.header.emit_key(document.contents.name)
    }
}
```

This also brings us a little closer to allowing CollectionDocument to use borrowed data, but that will be a bit more of an involved change, maybe involving updates to `transmog`.