### PR TITLE
Fixed default server listener

### DIFF
--- a/crates/bonsaidb-server/src/config.rs
+++ b/crates/bonsaidb-server/src/config.rs
@@ -305,7 +305,7 @@ pub struct BonsaiListenConfig {
 impl Default for BonsaiListenConfig {
     fn default() -> Self {
         Self {
-            address: SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 5465, 0, 0)),
+            address: SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 5645, 0, 0)),
             reuse_address: false,
         }
     }


### PR DESCRIPTION
A breaking change was introduced in the commit a22d45966b0e89c34586ae76b5552c36746b016c, likely by mistake, because it's not mentioned in the CHANGELOG. Should be Ipv6Addr::UNSPECIFIED which stands for [0; 8], instead of Ipv6Addr::LOCALHOST. Strange that remote server by default would only listen on localhost.

Also, port 5645 instead of 5465. Easy to make a mistake here.